### PR TITLE
Generate Tx & Rx Callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,142 @@
   for each of these specific ECUs dedicated "###-binutil.c/h" pair of source code will be generated.
   
   See help output using details.
+
+  ## "-rxcb" option
+
+  If you want to generate function callback stubs for each signal, using `-rxcb` with codedbc
+  will generate NULL defined stubs. Assign any of the generated callbacks to have them be executed
+  automatically when the associated signal is unpacked. See code snippet below for example use.
+
+  ```c
+  #include "conf/canmessages-config.h"
+  #include "lib/canmessages.h"
+  #include "butl/nodea_canmessages-binutil.h"
+  #include "butl/nodeb_canmessages-binutil.h"
+  #include "common_tuner.h"
+
+  // Signal NodeAtoTuner_SeekRequest; Callback for function NodeAtoTuner_SeekRequest_cb
+  void SiLabs_Tuner_SeekRequest(uint8_t direction)
+  {
+      uint8_t seek_dir = (direction == CANMessages_Signal_NodeA_SeekRequest_Up) ? 1 : 0;
+      RETURN_TYPE ret = SiLabs_Tuner_fm_seek_start(tuner_handle, seek_dir);
+      if (ret != SUCCESS)
+      {
+          LOG_MACRO("C-CODERDBC", "%s:%d > %s(): Tuner failed to seek (direction %d); ret=%d", __FILE__, __LINE__, __func__, direction, ret);
+      }
+  }
+
+  int main(int argc, char* argv[])
+  {
+      // Assign CAN database callbacks
+      DisplayToTuner_SeekRequest_cb = Si479xx_SeekRequest;
+
+      while (true)
+      {
+          // Receive a CAN frame from the CAN Bus
+          uint8_t canFrame_dataLength, canFrame_data[8];
+          uint32_t canFrame_id;
+          CAN_HAL_RX_CANFrame(canFrame_data, &canFrame_id, &canFrame_dataLength);
+
+          // Parse the received CAN frame with the CAN database generated code; callbacks triggered automatically
+          canmessages_rx_t msg;
+          canmessages_Receive(&msg, canFrame_data, canFrame_id, canFrame_dataLength);
+      }
+  }
+  ```
+
+  ## "-canstruct <path/to/header.h>" option
+
+  Use this option if you have a header which defines the `__CoderDbcCanFrame_t__` struct. This will insert your
+  header into the generated files so you don't have to modify the generated code to define/redefine generated code.
+
+  ## "-usestruct" option
+
+  Use this option to enable the macro which allows for use of a CAN frame struct instead of passing the individual variables.
+
+  ## "-defstruct <typedef struct {/\*definition\*/} __CoderDbcCanFrame_t__;>" option
+
+  Use this option to define the CAN struct during code generation instead of modifying generated code or providing a path to 
+  a header which defines it instead.  
+  Can be used with option `-canstruct` to provide an existing struct definition and assigning __CoderDbcCanFrame_t__ to it:  
+  `-canstruct "driver/twai.h" -defstruct "typedef twai_message_t __CoderDbcCanFrame_t__;"`
+
+  ## "-txcb" option
+
+  If you want to generate a function callback stub for sending a CAN frame after packing a signal,
+  using `-txcb` with codedbc will generate a NULL defined stub. Assign the generated callback to have
+  it execute automatically after packing a signal. See code snippet below for example use.
+
+  ```c++
+  #include "conf/canmessages-config.h"
+  #include "lib/canmessages.h"
+  #include "butl/nodea_canmessages-binutil.h"
+  #include "butl/nodeb_canmessages-binutil.h"
+  #include "common_tuner.h"
+  #include "driver/gpio.h"
+  #include "driver/twai.h"
+  #include "freertos/FreeRTOS.h"
+  #include "freertos/queue.h"
+  #include "freertos/semphr.h"
+  #include "freertos/task.h"
+  #include "hal/gpio_types.h"
+
+  #if CANMESSAGES_USE_CANSTRUCT
+  extern "C" void SendMessage(__CoderDbcCanFrame_t__ frame)
+  {
+  #else
+  extern "C" void SendMessage(uint32_t _id, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+  {
+    twai_message_t frame = {
+      .extd = *ide,
+      .identifier = _id,
+      .data_length_code = *_len,
+      .data = _d
+    };
+  #endif
+      xSemaphoreTake(g_canSemaphore, portMAX_DELAY);
+      twai_transmit(&(twai_message_t)frame, pdMS_TO_TICKS(DEFINED_DELAY));
+      xSemaphoreGive(g_canSemaphore);
+  }
+
+
+  int main(int argc, char* argv[])
+  {
+      Init_Drivers();
+
+      // Assign CAN database TX callback
+      CANMessages_TX_cb = SendMessage;
+
+      while (true)
+      {
+          /* Stuff being done... */
+
+          if (tune_to_channel)
+          {
+            // Display needs to tell Tuner to tune to station 100.5
+            NodeA_TuneToFrequency_t msg = { .Frequency = 100500 };
+            #if CANMESSAGES_USE_CANSTRUCT
+            __CoderDbcCanFrame_t__ frame;
+            Pack_NodeA_TuneToFrequency_CANMessages(&msg, &frame);
+            #else
+            uint8_t data[8], len=8, ide;
+            Pack_NodeA_TuneToFrequency_CANMessages(&msg, NodeA_TuneToFrequency_CANID, data, &len, &ide);
+            #endif
+
+            /* Alternatively, using the helper macro to send a CAN frame */
+            CANdySend_CANMessages(NodeA_TuneToFrequency, { .Frequency = 100500 });
+          }
+
+          /* Handling a received signal */
+
+          uint8_t canFrame_dataLength, canFrame_data[8];
+          uint32_t canFrame_id;
+          CAN_HAL_RX_CANFrame(canFrame_data, &canFrame_id, &canFrame_dataLength);
+
+          // Parse the received CAN frame with the CAN database generated code; callbacks triggered automatically
+          canmessages_rx_t msg;
+          canmessages_Receive(&msg, canFrame_data, canFrame_id, canFrame_dataLength);
+      }
+  }
+  ```
+

--- a/run-test-gen.sh
+++ b/run-test-gen.sh
@@ -1,1 +1,11 @@
-./build/coderdbc -dbc test/testdb.dbc -out test/gencode -drvname testdb -nodeutils -rw
+#!/bin/bash
+
+if [[ -z "$1" ]]; then
+    CANDB=$(ls *.dbc | head -n 1)
+    echo "CAN Database file not provided. Using \"${CANDB}\""
+else
+    CANDB="$1"
+fi
+
+# ./build/coderdbc -dbc ${CANDB} -out generated -drvname CANMessages -canstruct "../main/dbc_to_twai.h" -usestruct -nodeutils -rw -rxcb -txcb
+./build/coderdbc -dbc ${CANDB} -out generated -drvname CANMessages -canstruct "driver/twai.h" -defstruct "typedef twai_message_t __CoderDbcCanFrame_t__;" -usestruct -nodeutils -rw -rxcb -txcb

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -263,14 +263,13 @@ void CiMainGenerator::Gen_MainHeader()
 
     // write the callback struct for signals that can be receieved
     fwriter->AppendLine(StrPrint("#ifdef %s", fdesc->userxcb_def.c_str()));
-    // fwriter->AppendLine(StrPrint("void (*%s_cb)(%s_t) = NULL;", m.Name.c_str()), 2);
-    std::string cbWithParams = "void (*" + m.Name + "_cb)(";
+    std::string cbWithParams = "extern void (*" + m.Name + "_cb)(";
     for (size_t signum = 0; signum < m.Signals.size(); signum++)
     {
       cbWithParams += PrintType((int)m.Signals[signum].TypeRo) + " " + m.Signals[signum].Name;
       if (signum == (m.Signals.size() - 1))
       {
-        cbWithParams += ") = NULL;";
+        cbWithParams += ");";
       }
       else
       {
@@ -339,6 +338,29 @@ void CiMainGenerator::Gen_MainSource()
   fwriter->AppendLine(StrPrint("#include <%s-fmon.h>", fdesc->drvname.c_str()), 2);
 
   fwriter->AppendLine(StrPrint("#endif // %s", fdesc->usemon_def.c_str()), 3);
+
+  // write the callback struct for signals that can be receieved
+  fwriter->AppendLine("// Callback prototypes which will be used if assigned");
+  fwriter->AppendLine(StrPrint("#ifdef %s", fdesc->userxcb_def.c_str()));
+  for (size_t num = 0; num < sigprt->sigs_expr.size(); num++)
+  {
+    MessageDescriptor_t& m = sigprt->sigs_expr[num]->msg;
+    std::string cbWithParams = "void (*" + m.Name + "_cb)(";
+    for (size_t signum = 0; signum < m.Signals.size(); signum++)
+    {
+      cbWithParams += PrintType((int)m.Signals[signum].TypeRo) + " " + m.Signals[signum].Name;
+      if (signum == (m.Signals.size() - 1))
+      {
+        cbWithParams += ") = NULL;";
+      }
+      else
+      {
+        cbWithParams += ", ";
+      }
+    }
+    fwriter->AppendLine(cbWithParams);
+  }
+  fwriter->AppendLine(StrPrint("#endif // %s", fdesc->userxcb_def.c_str()), 2);
 
   fwriter->AppendLine(StrPrint(extend_func_body, ext_sig_func_name), 1);
 
@@ -1105,4 +1127,3 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
     fwriter->AppendLine(StrPrint("#endif // %s", fdesc->usecsm_def.c_str()), 2);
   }
 }
-

--- a/src/codegen/c-main-generator.h
+++ b/src/codegen/c-main-generator.h
@@ -7,11 +7,20 @@
 #include "../types/outfile.h"
 #include "fs-creator.h"
 
+typedef struct {
+  bool gen_rx_cbs; // generate c code with RX callback stubs
+  bool gen_tx_cb; // generate c code TX callback stub
+  bool can_structs; // enables CANMESSAGES_USE_CANSTRUCT macro during generation
+  bool can_defined; // generate CAN structure definition
+  bool struct_path_provided; // external CAN structure is provided
+  std::string can_struct_path; // path to header with __CoderDbcCanFrame_t__ conversion
+  std::string can_struct_def; // string defining the CAN struct
+} generator_params_t;
+
 class CiMainGenerator {
  public:
   CiMainGenerator();
-
-  void Generate(DbcMessageList_t& dlist, const FsDescriptor_t& fsd);
+  void Generate(DbcMessageList_t& dlist, const FsDescriptor_t& fsd, generator_params_t p);
 
  private:
 

--- a/src/codegen/c-util-generator.h
+++ b/src/codegen/c-util-generator.h
@@ -21,7 +21,7 @@ class CiUtilGenerator {
   // - optional (through define in global "dbccodeconf.h") variable allocation in source files
   //
   void Generate(DbcMessageList_t& dlist, const FsDescriptor_t& fsd,
-    const MsgsClassification& groups, const std::string& drvname);
+    const MsgsClassification& groups, const std::string& drvname, bool canstruct);
 
  private:
   void PrintHeader();

--- a/src/codegen/conditional-tree.cpp
+++ b/src/codegen/conditional-tree.cpp
@@ -61,7 +61,7 @@ void ConditionalTree::PrintCode(std::string& str, uint8_t indent)
 {
   while (indent--)
   {
-    codestr += " ";
+    codestr += "    ";
   }
 
   codestr += str;

--- a/src/codegen/fs-creator.cpp
+++ b/src/codegen/fs-creator.cpp
@@ -145,6 +145,18 @@ bool FsCreator::PrepareDirectory(std::string drvname, std::string basepath, bool
     snprintf(_tmpb, kTmpLen, "%s_USE_DIAG_MONITORS", FS.DRVNAME.c_str());
     FS.usemon_def = _tmpb;
 
+    snprintf(_tmpb, kTmpLen, "%s_USE_RX_CALLBACKS", FS.DRVNAME.c_str());
+    FS.userxcb_def = _tmpb;
+
+    snprintf(_tmpb, kTmpLen, "%s_USE_TX_CALLBACK", FS.DRVNAME.c_str());
+    FS.usetxcb_def = _tmpb;
+
+    snprintf(_tmpb, kTmpLen, "%s_TX_cb", FS.DrvName_orig.c_str());
+    FS.txcb_func = _tmpb;
+
+    snprintf(_tmpb, kTmpLen, "DBUG_%s_CB", FS.DRVNAME.c_str());
+    FS.debugcb_def = _tmpb;
+
     snprintf(_tmpb, kTmpLen, "%s_USE_SIGFLOAT", FS.DRVNAME.c_str());
     FS.usesigfloat_def = _tmpb;
 

--- a/src/codegen/fs-creator.h
+++ b/src/codegen/fs-creator.h
@@ -31,6 +31,10 @@ typedef struct
   std::string usebits_def;
   std::string usesruct_def;
   std::string usemon_def;
+  std::string userxcb_def;
+  std::string usetxcb_def;
+  std::string txcb_func;
+  std::string debugcb_def;
   std::string usesigfloat_def;
   std::string useroll_def;
   std::string usecsm_def;


### PR DESCRIPTION
Generates Callbacks for automatic CAN signal handling:

- `-rxcb`: Generates a NULL defined callback for each receivable signal
- `-txcb`: Generates a NULL defined callback stub for sending CAN signals; triggered after a message is packed
- `-canstruct "<path/to/header.h>"`: Generated `dbccodeconf.h` will include the provided header so generated code doesn't need to be modified
- `-usestruct`: Enables the macro during C Code generation which allows for use of a CAN frame struct instead of passing the individual variables
- `-defstruct "typedef <existing_can_frame_t> __CoderDbcCanFrame_t__;"`: Defines the CAN struct during code generation instead of modifying generated code and can be used with `-canstruct` to provide and assign an existing struct