### PR TITLE
added multiplex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,77 @@
-  # CODERDBC 
+# CODERDBC 
   
-  ## What is it
+Coderdbc is a CLI utility for generating C code from DBC CAN matrix files
 
-  CLI utilty for generating C code from dbc (CAN matrix) files
+### Features
+- ***Pack*** and ***Unpack*** functions for conversion signals to CAN payload raw data and vice verse
+- ***Node based*** Receive function _(each node (ECU) has its own ***Receive*** function according to its DBC configuration)_
+- Automation on monitoring functions: CRC, counter and missing tests
+- Optional source code generation _(the generation of readonly and configuration files can be avoided)_
+- Flexible setup via driver configuration _(see comments in source code for details)_
 
-  ## Build and run
+## Build and run
 
-  This manual works on Ubuntu 20.04 and Windows 10. You need to ensure that your system has
-  C++ compile and builing toolchain (**c++17**)
+For building project you need to have cmake and c++ development toolkit in your system
+1 download source code:
+```sh
+git clone https://github.com/astand/c-coderdbc.git coderdbc
+```
+Go to the source code directory:
+```sh
+cd coderdbc
+```
+Run cmake configuration to 'build' directory:
+```sh
+cmake -S src -B build
+```
+Run cmake build:
+```sh
+--build build --config release
+```
+Go to the build directory and run:
+```sh
+cd build
+./coderdbc --help
+```
 
-  To build coderdbc you need to make next steps:
-  
-  1 install cmake
-  
-  2 download source code:
+Help information with main instructions about using the tool will be printed
 
-  `git clone https://github.com/astand/c-coderdbc.git coderdbc`
-  
-  3 goto source code directory:
+## Driver functionality description
 
-  `cd coderdbc`
-
-  4 run cmake configuration to 'build' directory:
-
-  `cmake -S src -B build`
-
-  5 run cmake build:
-
-  `cmake --build build --config release`
-
-  6 goto to build directory and run:
-
-  `cd build`
-
-  `./coderdbc`
-
-  Call without argument will print instruction how to pass DBC file for generation
-
-  ## Driver functionality description
-
-  The full pack of source code (both generated and manually edited) will be looked this
-  (presuming that the dbc driver name is "ecudb"):
+    The source code package includes the following source files (presuming that the dbc driver name is "ecudb"):
       
-     ecudb.c / ecudb.h                             (1) RO / lib
+      ecudb.c / ecudb.h                            (1) RO / lib
 
-    Main driver which has all dbc frames structs / pack functions / unpack functions these 
-    source files preferably to place in lib level directory because they are RO using model
-    and can be 
-    shared among few separated projects.
-
+    Pair of the main driver which contains all dbc frames structs / pack functions / unpack functions declarations. These source files preferably to place in the share/library directory. This part of the package is non-changable and has no any data, so can be used across multi projects.
+    
       ecudb-fmon.h                                 (2) RO / lib
 
-    Contains monitoring functions signatures which can be optionally called from unpack frame. 
-    Best option to place file beside Main driver files (1).
+    Fmon header is a readonly part of monitoring part of the package. It contains the list of functions for CAN message validation. Those functions should be defined in the scope of user code and can be optionally used in unpack messages. This file is preferably to place in the share/library directory next to the main driver source files.
 
       ecudb-fmon.c                                 (3) app
 
-    User defined functions with diagnostic purpose. DLC, rolling, checksum errors can be handled 
-    automatically if specific configuration enabled. This file is user level source code.
+    User specific part of monitoring functionality. If monitoring is fully enabled user code must define all the monitoring functions. This file is a part of the scope of user code.
 
       ecudb-config.h                               (4) app / inc*
 
-    This is application specific configuration file. If you have a few projects (applications) 
-    which referenced on single main driver (1,2) then each project have to have own copy of this 
-    configuration. Source code (1,2) includes this configuration. If a few dbc matrix is in use 
-    in your application then for each of (1,2) specific configuration file must be presented.
+    An application specific configuration file for enabling features in the main driver. If there are a few projects (applications) which include a single main driver (1,2) then each project has to have its own copy of this configuration. Source code (1,2) includes this configuration. If a few dbc matrix is in use in your application then for each of (1,2) specific configuration file must be presented.
 
       dbccodeconf.h                                (5) app / inc
 
-    This is application specific configuration file. This file may include "CanFrame" definition,
-    sigfloat_t typedef and binutil macros which enables rx and tx structures allocation inside 
-    ecudb-binutil.c. This file must be single for application (see template dbccodeconf.h), source
-    code (4,6) includes this configuration.
+    Application specific configuration file. This file might include "CanFrame" definition, sigfloat_t typedef and binutil macros which enables rx and tx structures allocation inside ecudb-binutil.c. Each project has to have its own copy of this configuration (see template dbccodeconf.h). Source code (4,6) includes this configuration.
 
       ecudb-binutil.c / ecudb-binutil.h            (6) RO / app
 
-    Basically this is application specific file. This driver has one function which intakes CAN
-    message data and calls dedicated unpacking function. Function selection based on binary search. 
+    The part which is used for generalization CAN frame flow receiving and unpacking. It also optionally can allocate CAN frame tx/rx structs. 
     
       canmonitorutil.h                             (7) lib
 
-    This is lib level source code. This file is basic for all automatic monitoring functions. 
-    This configuration file location have to be added to project include path.
+    General definitions for monitoring feature. The source file can be place to the share/library directory.
     
     -----------------------------------------------------------------------------------------------
 
     *inc - file location have to be added to project include path.
 
-  ## "-nodeutils" option
+## generation options
 
-  If your matrix has strict routing setup, where each CAN device (node) has defined collection 
-  of TX frames as well as defined collection of RX frames the "-nodeutils" option may be used.
-  In this mode all the nodes defined in CAN matrix will be handled as specific ECU and 
-  for each of these specific ECUs dedicated "###-binutil.c/h" pair of source code will be generated.
-  
-  See help output using details.
+  There are several available generation option, use '-help' option for details

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cmake -S src -B build
 ```
 Run cmake build:
 ```sh
---build build --config release
+cmake --build build --config release
 ```
 Go to the build directory and run:
 ```sh

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -31,10 +31,10 @@ void CoderApp::Run()
 /// @brief Main generation process
 void CoderApp::GenerateCode()
 {
-  auto scanner = std::make_unique<DbcScanner>();
-  auto cigen = std::make_unique<CiMainGenerator>();
-  auto ciugen = std::make_unique<CiUtilGenerator>();
-  auto fscreator = std::make_unique<FsCreator>();
+  DbcScanner scanner;
+  CiMainGenerator cigen;
+  CiUtilGenerator ciugen;
+  FsCreator fscreator;
 
   std::ifstream reader;
 
@@ -52,22 +52,22 @@ void CoderApp::GenerateCode()
 
   std::istream& s = reader;
 
-  scanner->TrimDbcText(s);
+  scanner.TrimDbcText(s);
 
   std::string info("");
 
   // create main destination directory
-  fscreator->Configure(Params.drvname.first, Params.outdir.first, info, scanner->dblist.ver.hi, scanner->dblist.ver.low);
+  fscreator.Configure(Params.drvname.first, Params.outdir.first, info, scanner.dblist.ver.hi, scanner.dblist.ver.low);
 
-  auto ret = fscreator->PrepareDirectory(Params.is_rewrite);
+  auto ret = fscreator.PrepareDirectory(Params.is_rewrite);
 
-  fscreator->FS.gen.no_config = Params.is_noconfig;
-  fscreator->FS.gen.no_inc = Params.is_nocanmon;
-  fscreator->FS.gen.no_fmon = Params.is_nofmon;
+  fscreator.FS.gen.no_config = Params.is_noconfig;
+  fscreator.FS.gen.no_inc = Params.is_nocanmon;
+  fscreator.FS.gen.no_fmon = Params.is_nofmon;
 
   if (ret)
   {
-    cigen->Generate(scanner->dblist, fscreator->FS);
+    cigen.Generate(scanner.dblist, fscreator.FS);
   }
   else
   {
@@ -80,10 +80,10 @@ void CoderApp::GenerateCode()
   {
     std::vector<std::string> nodes;
 
-    for (size_t num = 0; num < scanner->dblist.msgs.size(); num++)
+    for (size_t num = 0; num < scanner.dblist.msgs.size(); num++)
     {
       // iterate all messages and collect All nodes assign to at least one message
-      auto m = scanner->dblist.msgs[num];
+      auto m = scanner.dblist.msgs[num];
 
       for (size_t txs = 0; txs < m->TranS.size(); txs++)
       {
@@ -115,22 +115,22 @@ void CoderApp::GenerateCode()
       std::string util_name = nodes[node] + "_" + Params.drvname.first;
 
       // set new driver name for current node
-      fscreator->FS.gen.drvname = str_tolower(util_name);
-      fscreator->FS.gen.DRVNAME = str_toupper(fscreator->FS.gen.drvname);
-      fscreator->FS.file.util_c.dir = fscreator->FS.file.utildir;
-      fscreator->FS.file.util_h.dir = fscreator->FS.file.utildir;
+      fscreator.FS.gen.drvname = str_tolower(util_name);
+      fscreator.FS.gen.DRVNAME = str_toupper(fscreator.FS.gen.drvname);
+      fscreator.FS.file.util_c.dir = fscreator.FS.file.utildir;
+      fscreator.FS.file.util_h.dir = fscreator.FS.file.utildir;
 
-      fscreator->FS.file.util_h.fname = str_tolower(fscreator->FS.gen.drvname + "-binutil.h");
-      fscreator->FS.file.util_h.fpath = fscreator->FS.file.utildir + "/" + fscreator->FS.file.util_h.fname;
+      fscreator.FS.file.util_h.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.h");
+      fscreator.FS.file.util_h.fpath = fscreator.FS.file.utildir + "/" + fscreator.FS.file.util_h.fname;
 
-      fscreator->FS.file.util_c.fname = str_tolower(fscreator->FS.gen.drvname + "-binutil.c");
-      fscreator->FS.file.util_c.fpath = fscreator->FS.file.utildir + "/" + fscreator->FS.file.util_c.fname;
+      fscreator.FS.file.util_c.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.c");
+      fscreator.FS.file.util_c.fpath = fscreator.FS.file.utildir + "/" + fscreator.FS.file.util_c.fname;
 
       MsgsClassification groups;
 
-      for (size_t i = 0; i < scanner->dblist.msgs.size(); i++)
+      for (size_t i = 0; i < scanner.dblist.msgs.size(); i++)
       {
-        auto m = scanner->dblist.msgs[i];
+        auto m = scanner.dblist.msgs[i];
 
         bool found = (std::find(m->TranS.begin(), m->TranS.end(), nodes[node]) != m->TranS.end());
 
@@ -151,7 +151,7 @@ void CoderApp::GenerateCode()
 
       if (ret)
       {
-        ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.first);
+        ciugen.Generate(scanner.dblist, fscreator.FS, groups, Params.drvname.first);
       }
     }
   }
@@ -159,14 +159,14 @@ void CoderApp::GenerateCode()
   {
     MsgsClassification groups;
 
-    for (size_t i = 0; i < scanner->dblist.msgs.size(); i++)
+    for (size_t i = 0; i < scanner.dblist.msgs.size(); i++)
     {
-      groups.Rx.push_back(scanner->dblist.msgs[i]->MsgID);
+      groups.Rx.push_back(scanner.dblist.msgs[i]->MsgID);
     }
 
     if (ret)
     {
-      ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.first);
+      ciugen.Generate(scanner.dblist, fscreator.FS, groups, Params.drvname.first);
     }
   }
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -18,7 +18,7 @@ void CoderApp::Run()
 {
   std::cout << "coderdbc v" << CODEGEN_LIB_VERSION_MAJ << "." << CODEGEN_LIB_VERSION_MIN << std::endl << std::endl;
 
-  if (ParseParams())
+  if (AreParamsValid())
   {
     GenerateCode();
   }
@@ -28,6 +28,7 @@ void CoderApp::Run()
   }
 }
 
+/// @brief Main generation process
 void CoderApp::GenerateCode()
 {
   auto scanner = std::make_unique<DbcScanner>();
@@ -37,17 +38,17 @@ void CoderApp::GenerateCode()
 
   std::ifstream reader;
 
-  std::cout << "dbc file : " << Params.dbc.value << std::endl;
-  std::cout << "gen path : " << Params.outdir.value << std::endl;
-  std::cout << "drv name : " << Params.drvname.value << std::endl;
+  std::cout << "dbc file : " << Params.dbc.first << std::endl;
+  std::cout << "gen path : " << Params.outdir.first << std::endl;
+  std::cout << "drv name : " << Params.drvname.first << std::endl;
 
-  if (std::filesystem::exists(Params.dbc.value) == false)
+  if (std::filesystem::exists(Params.dbc.first) == false)
   {
     std::cout << "DBC file is not exists!" << std::endl;
     return;
   }
 
-  reader.open(Params.dbc.value);
+  reader.open(Params.dbc.first);
 
   std::istream& s = reader;
 
@@ -56,7 +57,7 @@ void CoderApp::GenerateCode()
   std::string info("");
 
   // create main destination directory
-  fscreator->Configure(Params.drvname.value, Params.outdir.value, info, scanner->dblist.ver.hi, scanner->dblist.ver.low);
+  fscreator->Configure(Params.drvname.first, Params.outdir.first, info, scanner->dblist.ver.hi, scanner->dblist.ver.low);
 
   auto ret = fscreator->PrepareDirectory(Params.is_rewrite);
 
@@ -111,7 +112,7 @@ void CoderApp::GenerateCode()
     // for each node in collection perform specific bin-util generation
     for (size_t node = 0; node < nodes.size(); node++)
     {
-      std::string util_name = nodes[node] + "_" + Params.drvname.value;
+      std::string util_name = nodes[node] + "_" + Params.drvname.first;
 
       // set new driver name for current node
       fscreator->FS.gen.drvname = str_tolower(util_name);
@@ -150,7 +151,7 @@ void CoderApp::GenerateCode()
 
       if (ret)
       {
-        ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.value);
+        ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.first);
       }
     }
   }
@@ -165,16 +166,19 @@ void CoderApp::GenerateCode()
 
     if (ret)
     {
-      ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.value);
+      ciugen->Generate(scanner->dblist, fscreator->FS, groups, Params.drvname.first);
     }
   }
 }
 
-bool CoderApp::ParseParams()
+/// @brief Checks if all mandatory configuration parameters are provided
+/// @return TRUE if configuration valid, otherwise FALSE
+bool CoderApp::AreParamsValid()
 {
-  return (Params.dbc.ok && Params.outdir.ok && Params.drvname.ok) && (Params.is_help == false);
+  return (Params.dbc.second && Params.outdir.second && Params.drvname.second) && (Params.is_help == false);
 }
 
+/// @brief Help message printer
 void CoderApp::PrintHelp()
 {
   std::cout << "project source code:\thttps://github.com/astand/c-coderdbc\t\t" << std::endl;

--- a/src/app.h
+++ b/src/app.h
@@ -5,16 +5,20 @@
 #include <string>
 #include <options-parser.h>
 
+/// @brief App wrapper class
 class CoderApp {
  public:
-  CoderApp(const OptionsParser::Pairs& params) : Params(params) {}
+  /// @brief Constructor
+  /// @param params - general generation configuration
+  CoderApp(const OptionsParser::GenOptions& params) : Params(params) {}
 
+  /// @brief Main generation process
   void Run();
 
  private:
-  bool ParseParams();
+  bool AreParamsValid();
   void GenerateCode();
   void PrintHelp();
 
-  const OptionsParser::Pairs& Params;
+  const OptionsParser::GenOptions& Params;
 };

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -31,22 +31,16 @@ const char* extend_func_body =
   "  return (val ^ m) - m;\n"
   "}\n\n";
 
-CiMainGenerator::CiMainGenerator()
-{
-  sigprt = std::make_unique<CSigPrinter>();
-  fwriter = std::make_unique<FileWriter>();
-}
-
 void CiMainGenerator::Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd)
 {
   // Load income messages to sig printer
-  sigprt->LoadMessages(dlist.msgs);
+  sigprt.LoadMessages(dlist.msgs);
 
   // save pointer to output file descriptor struct to
   // enable using this information inside class member functions
   fdesc = &fsd;
 
-  std::sort(sigprt->sigs_expr.begin(), sigprt->sigs_expr.end(),
+  std::sort(sigprt.sigs_expr.begin(), sigprt.sigs_expr.end(),
     [](const CiExpr_t* a, const CiExpr_t* b) -> bool
   {
     return a->msg.MsgID < b->msg.MsgID;
@@ -91,56 +85,56 @@ void CiMainGenerator::Gen_MainHeader()
   if (fdesc->gen.start_info.size() > 0)
   {
     // replace all '\n' on "\n //" for c code comment text
-    fwriter->Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
+    fwriter.Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
   }
 
-  fwriter->Append("#pragma once");
-  fwriter->Append();
-  fwriter->Append("#ifdef __cplusplus\nextern \"C\" {\n#endif");
-  fwriter->Append();
-  fwriter->Append("#include <stdint.h>");
-  fwriter->Append();
+  fwriter.Append("#pragma once");
+  fwriter.Append();
+  fwriter.Append("#ifdef __cplusplus\nextern \"C\" {\n#endif");
+  fwriter.Append();
+  fwriter.Append("#include <stdint.h>");
+  fwriter.Append();
 
-  fwriter->Append("// DBC file version");
-  fwriter->Append("#define %s (%uU)", fdesc->gen.verhigh_def.c_str(), fdesc->gen.hiver);
-  fwriter->Append("#define %s (%uU)", fdesc->gen.verlow_def.c_str(), fdesc->gen.lowver);
-  fwriter->Append();
+  fwriter.Append("// DBC file version");
+  fwriter.Append("#define %s (%uU)", fdesc->gen.verhigh_def.c_str(), fdesc->gen.hiver);
+  fwriter.Append("#define %s (%uU)", fdesc->gen.verlow_def.c_str(), fdesc->gen.lowver);
+  fwriter.Append();
 
-  fwriter->Append("// include current dbc-driver compilation config");
-  fwriter->Append("#include <%s-config.h>", fdesc->gen.drvname.c_str());
-  fwriter->Append();
+  fwriter.Append("// include current dbc-driver compilation config");
+  fwriter.Append("#include <%s-config.h>", fdesc->gen.drvname.c_str());
+  fwriter.Append();
 
-  fwriter->Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
 
-  fwriter->Append(
+  fwriter.Append(
     "// This file must define:\n"
     "// base monitor struct\n"
     "#include <canmonitorutil.h>\n"
     "\n"
   );
 
-  fwriter->Append("#endif // %s", fdesc->gen.usemon_def.c_str());
-  fwriter->Append(2);
+  fwriter.Append("#endif // %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append(2);
 
-  for (size_t num = 0; num < sigprt->sigs_expr.size(); num++)
+  for (size_t num = 0; num < sigprt.sigs_expr.size(); num++)
   {
     // write message typedef s and additional expressions
-    MessageDescriptor_t& m = sigprt->sigs_expr[num]->msg;
+    MessageDescriptor_t& m = sigprt.sigs_expr[num]->msg;
 
     if (m.CommentText.size() > 0)
     {
       // replace all '\n' on "\n //" for c code comment text
-      fwriter->Append("// " + std::regex_replace(m.CommentText, std::regex("\n"), "\n// "));
+      fwriter.Append("// " + std::regex_replace(m.CommentText, std::regex("\n"), "\n// "));
     }
 
-    fwriter->Append("// def @%s CAN Message (%-4d %#x)", m.Name.c_str(), m.MsgID, m.MsgID);
-    fwriter->Append("#define %s_IDE (%uU)", m.Name.c_str(), m.IsExt);
-    fwriter->Append("#define %s_DLC (%uU)", m.Name.c_str(), m.DLC);
-    fwriter->Append("#define %s_CANID (%#x)", m.Name.c_str(), m.MsgID);
+    fwriter.Append("// def @%s CAN Message (%-4d %#x)", m.Name.c_str(), m.MsgID, m.MsgID);
+    fwriter.Append("#define %s_IDE (%uU)", m.Name.c_str(), m.IsExt);
+    fwriter.Append("#define %s_DLC (%uU)", m.Name.c_str(), m.DLC);
+    fwriter.Append("#define %s_CANID (%#x)", m.Name.c_str(), m.MsgID);
 
     if (m.Cycle > 0)
     {
-      fwriter->Append("#define %s_CYC (%dU)", m.Name.c_str(), m.Cycle);
+      fwriter.Append("#define %s_CYC (%dU)", m.Name.c_str(), m.Cycle);
     }
 
     size_t max_sig_name_len = 27;
@@ -154,7 +148,7 @@ void CiMainGenerator::Gen_MainHeader()
         if (passed_sigs.find(s.Name) == passed_sigs.end())
         {
           // print signal macroses only it was not printed before
-          fwriter->Append(sigprt->PrintPhysicalToRaw(&s, fdesc->gen.DRVNAME));
+          fwriter.Append(sigprt.PrintPhysicalToRaw(&s, fdesc->gen.DRVNAME));
           passed_sigs.insert(s.Name);
         }
       }
@@ -167,8 +161,8 @@ void CiMainGenerator::Gen_MainHeader()
       // For each signal in current message print value tables definitions
       if (s.ValDefs.vpairs.size() > 0)
       {
-        fwriter->Append("\n// Value tables for @%s signal", s.Name.c_str());
-        fwriter->Append();
+        fwriter.Append("\n// Value tables for @%s signal", s.Name.c_str());
+        fwriter.Append();
 
         for (auto i = 0; i < s.ValDefs.vpairs.size(); i++)
         {
@@ -179,25 +173,25 @@ void CiMainGenerator::Gen_MainHeader()
           // @ifndef guard for the case when different values of table have
           // the same name (it is valid for DBC file format)
           // For this case only one of same named values will be available as macro
-          fwriter->Append("#ifndef %s", defname.c_str());
+          fwriter.Append("#ifndef %s", defname.c_str());
 
-          fwriter->Append("#define %s_%s_%s (%d)",
+          fwriter.Append("#define %s_%s_%s (%d)",
             s.Name.c_str(), m.Name.c_str(), s.ValDefs.vpairs[i].first.c_str(),
             s.ValDefs.vpairs[i].second);
 
-          fwriter->Append("#endif");
-          fwriter->Append();
+          fwriter.Append("#endif");
+          fwriter.Append();
         }
       }
     }
 
-    fwriter->Append();
-    fwriter->Append("typedef struct");
-    fwriter->Append("{");
+    fwriter.Append();
+    fwriter.Append("typedef struct");
+    fwriter.Append("{");
 
     // Write section for bitfielded part
-    fwriter->Append("#ifdef %s", fdesc->gen.usebits_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#ifdef %s", fdesc->gen.usebits_def.c_str());
+    fwriter.Append();
 
     SignalDescriptor_t rollsig;
 
@@ -218,16 +212,16 @@ void CiMainGenerator::Gen_MainHeader()
 
     if (m.RollSig != nullptr)
     {
-      fwriter->Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
-      fwriter->Append();
+      fwriter.Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
+      fwriter.Append();
       WriteSigStructField(rollsig, true, max_sig_name_len);
-      fwriter->Append("#endif // %s", fdesc->gen.useroll_def.c_str());
-      fwriter->Append();
+      fwriter.Append("#endif // %s", fdesc->gen.useroll_def.c_str());
+      fwriter.Append();
     }
 
     // Write clean part
-    fwriter->Append("#else");
-    fwriter->Append();
+    fwriter.Append("#else");
+    fwriter.Append();
 
     for (size_t signum = 0; signum < m.Signals.size(); signum++)
     {
@@ -238,56 +232,56 @@ void CiMainGenerator::Gen_MainHeader()
 
     if (m.RollSig != nullptr)
     {
-      fwriter->Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
-      fwriter->Append();
+      fwriter.Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
+      fwriter.Append();
       WriteSigStructField(rollsig, false, max_sig_name_len);
-      fwriter->Append("#endif // %s", fdesc->gen.useroll_def.c_str());
-      fwriter->Append();
+      fwriter.Append("#endif // %s", fdesc->gen.useroll_def.c_str());
+      fwriter.Append();
     }
 
-    fwriter->Append("#endif // %s", fdesc->gen.usebits_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usebits_def.c_str());
+    fwriter.Append();
 
     // start mon1 section
-    fwriter->Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
-    fwriter->Append();
-    fwriter->Append("  FrameMonitor_t mon1;");
-    fwriter->Append();
-    fwriter->Append("#endif // %s", fdesc->gen.usemon_def.c_str());
-    fwriter->Append();
-    fwriter->Append("} %s_t;", m.Name.c_str());
-    fwriter->Append();
+    fwriter.Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
+    fwriter.Append();
+    fwriter.Append("  FrameMonitor_t mon1;");
+    fwriter.Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usemon_def.c_str());
+    fwriter.Append();
+    fwriter.Append("} %s_t;", m.Name.c_str());
+    fwriter.Append();
   }
 
-  fwriter->Append("// Function signatures");
-  fwriter->Append();
+  fwriter.Append("// Function signatures");
+  fwriter.Append();
 
-  for (size_t num = 0; num < sigprt->sigs_expr.size(); num++)
+  for (size_t num = 0; num < sigprt.sigs_expr.size(); num++)
   {
     // write message typedef s and additional expressions
-    MessageDescriptor_t& m = sigprt->sigs_expr[num]->msg;
+    MessageDescriptor_t& m = sigprt.sigs_expr[num]->msg;
 
-    fwriter->Append("uint32_t Unpack_%s_%s(%s_t* _m, const uint8_t* _d, uint8_t dlc_);",
+    fwriter.Append("uint32_t Unpack_%s_%s(%s_t* _m, const uint8_t* _d, uint8_t dlc_);",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
-    fwriter->Append("#ifdef %s", fdesc->gen.usesruct_def.c_str());
+    fwriter.Append("#ifdef %s", fdesc->gen.usesruct_def.c_str());
 
-    fwriter->Append("uint32_t Pack_%s_%s(%s_t* _m, __CoderDbcCanFrame_t__* cframe);",
+    fwriter.Append("uint32_t Pack_%s_%s(%s_t* _m, __CoderDbcCanFrame_t__* cframe);",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
-    fwriter->Append("#else");
+    fwriter.Append("#else");
 
-    fwriter->Append("uint32_t Pack_%s_%s(%s_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);",
+    fwriter.Append("uint32_t Pack_%s_%s(%s_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
-    fwriter->Append("#endif // %s", fdesc->gen.usesruct_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usesruct_def.c_str());
+    fwriter.Append();
   }
 
-  fwriter->Append("#ifdef __cplusplus\n}\n#endif");
+  fwriter.Append("#ifdef __cplusplus\n}\n#endif");
 
   // save fwrite cached text to file
-  fwriter->Flush(fdesc->file.core_h.fpath);
+  fwriter.Flush(fdesc->file.core_h.fpath);
 }
 
 void CiMainGenerator::Gen_MainSource()
@@ -295,100 +289,100 @@ void CiMainGenerator::Gen_MainSource()
   if (fdesc->gen.start_info.size() > 0)
   {
     // replace all '\n' on "\n //" for c code comment text
-    fwriter->Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
+    fwriter.Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
   }
 
   // include main header file
-  fwriter->Append("#include \"%s\"", fdesc->file.core_h.fname.c_str());
-  fwriter->Append(2);
+  fwriter.Append("#include \"%s\"", fdesc->file.core_h.fname.c_str());
+  fwriter.Append(2);
 
-  fwriter->Append("// DBC file version");
-  fwriter->Append("#if (%s != (%uU)) || (%s != (%uU))",
+  fwriter.Append("// DBC file version");
+  fwriter.Append("#if (%s != (%uU)) || (%s != (%uU))",
     fdesc->gen.verhigh_def.c_str(), fdesc->gen.hiver, fdesc->gen.verlow_def.c_str(), fdesc->gen.lowver);
 
-  fwriter->Append("#error The %s dbc source files have different versions", fdesc->gen.DRVNAME.c_str());
-  fwriter->Append("#endif");
-  fwriter->Append();
+  fwriter.Append("#error The %s dbc source files have different versions", fdesc->gen.DRVNAME.c_str());
+  fwriter.Append("#endif");
+  fwriter.Append();
 
   // put diagmonitor ifdef selection for including @drv-fmon header
   // with FMon_* signatures to call from unpack function
-  fwriter->Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
 
-  fwriter->Append(
+  fwriter.Append(
     "// Function prototypes to be called each time CAN frame is unpacked\n"
     "// FMon function may detect RC, CRC or DLC violation\n");
 
-  fwriter->Append("#include <%s-fmon.h>", fdesc->gen.drvname.c_str());
-  fwriter->Append();
+  fwriter.Append("#include <%s-fmon.h>", fdesc->gen.drvname.c_str());
+  fwriter.Append();
 
-  fwriter->Append("#endif // %s", fdesc->gen.usemon_def.c_str());
-  fwriter->Append("");
-  fwriter->Append("// This macro guard for the case when you need to enable");
-  fwriter->Append("// using diag monitors but there is no necessity in proper");
-  fwriter->Append("// SysTick provider. For providing one you need define macro");
-  fwriter->Append("// before this line - in dbccodeconf.h");
-  fwriter->Append("");
-  fwriter->Append("#ifndef GetSystemTick");
-  fwriter->Append("#define GetSystemTick() (0u)");
-  fwriter->Append("#endif");
-  fwriter->Append("");
-  fwriter->Append("// This macro guard is for the case when you want to build");
-  fwriter->Append("// app with enabled optoin auto CSM, but don't yet have");
-  fwriter->Append("// proper getframehash implementation");
-  fwriter->Append("");
-  fwriter->Append("#ifndef GetFrameHash");
-  fwriter->Append("#define GetFrameHash(a,b,c,d,e) (0u)");
-  fwriter->Append("#endif");
-  fwriter->Append();
+  fwriter.Append("#endif // %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append("");
+  fwriter.Append("// This macro guard for the case when you need to enable");
+  fwriter.Append("// using diag monitors but there is no necessity in proper");
+  fwriter.Append("// SysTick provider. For providing one you need define macro");
+  fwriter.Append("// before this line - in dbccodeconf.h");
+  fwriter.Append("");
+  fwriter.Append("#ifndef GetSystemTick");
+  fwriter.Append("#define GetSystemTick() (0u)");
+  fwriter.Append("#endif");
+  fwriter.Append("");
+  fwriter.Append("// This macro guard is for the case when you want to build");
+  fwriter.Append("// app with enabled optoin auto CSM, but don't yet have");
+  fwriter.Append("// proper getframehash implementation");
+  fwriter.Append("");
+  fwriter.Append("#ifndef GetFrameHash");
+  fwriter.Append("#define GetFrameHash(a,b,c,d,e) (0u)");
+  fwriter.Append("#endif");
+  fwriter.Append();
 
-  fwriter->Append(extend_func_body, ext_sig_func_name), 1;
+  fwriter.Append(extend_func_body, ext_sig_func_name), 1;
 
   // for each message 3 functions must be defined - 1 unpack function,
   // 2: pack with raw signature
   // 3: pack with canstruct
-  for (size_t num = 0; num < sigprt->sigs_expr.size(); num++)
+  for (size_t num = 0; num < sigprt.sigs_expr.size(); num++)
   {
     // write message typedef s and additional expressions
-    MessageDescriptor_t& m = sigprt->sigs_expr[num]->msg;
+    MessageDescriptor_t& m = sigprt.sigs_expr[num]->msg;
 
     // first function
-    fwriter->Append("uint32_t Unpack_%s_%s(%s_t* _m, const uint8_t* _d, uint8_t dlc_)\n{",
+    fwriter.Append("uint32_t Unpack_%s_%s(%s_t* _m, const uint8_t* _d, uint8_t dlc_)\n{",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
     // put dirt trick to avoid warning about unusing parameter
     // (dlc) when monitora are disabled. trick is better than
     // selection different signatures because of external API consistency
-    fwriter->Append("  (void)dlc_;");
+    fwriter.Append("  (void)dlc_;");
 
-    WriteUnpackBody(sigprt->sigs_expr[num]);
+    WriteUnpackBody(sigprt.sigs_expr[num]);
 
-    fwriter->Append("}");
-    fwriter->Append();
+    fwriter.Append("}");
+    fwriter.Append();
 
     // next one is the pack function for using with CANFrame struct
-    fwriter->Append("#ifdef %s", fdesc->gen.usesruct_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#ifdef %s", fdesc->gen.usesruct_def.c_str());
+    fwriter.Append();
 
     // second function
-    fwriter->Append("uint32_t Pack_%s_%s(%s_t* _m, __CoderDbcCanFrame_t__* cframe)",
+    fwriter.Append("uint32_t Pack_%s_%s(%s_t* _m, __CoderDbcCanFrame_t__* cframe)",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
-    WritePackStructBody(sigprt->sigs_expr[num]);
+    WritePackStructBody(sigprt.sigs_expr[num]);
 
-    fwriter->Append("#else");
-    fwriter->Append();
+    fwriter.Append("#else");
+    fwriter.Append();
 
     // third function
-    fwriter->Append("uint32_t Pack_%s_%s(%s_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)",
+    fwriter.Append("uint32_t Pack_%s_%s(%s_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)",
       m.Name.c_str(), fdesc->gen.DrvName_orig.c_str(), m.Name.c_str());
 
-    WritePackArrayBody(sigprt->sigs_expr[num]);
+    WritePackArrayBody(sigprt.sigs_expr[num]);
 
-    fwriter->Append("#endif // %s", fdesc->gen.usesruct_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usesruct_def.c_str());
+    fwriter.Append();
   }
 
-  fwriter->Flush(fdesc->file.core_c.fpath);
+  fwriter.Flush(fdesc->file.core_c.fpath);
 }
 
 void CiMainGenerator::Gen_ConfigHeader()
@@ -396,144 +390,144 @@ void CiMainGenerator::Gen_ConfigHeader()
   if (fdesc->gen.start_info.size() > 0)
   {
     // replace all '\n' on "\n //" for c code comment text
-    fwriter->Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
+    fwriter.Append("// " + std::regex_replace(fdesc->gen.start_info, std::regex("\n"), "\n// "));
   }
 
   ConfigGenerator confgen;
-  confgen.FillHeader((*fwriter), fdesc->gen);
+  confgen.FillHeader(fwriter, fdesc->gen);
 
-  fwriter->Flush(fdesc->file.confdir + '/' + fdesc->gen.drvname + "-config.h");
+  fwriter.Flush(fdesc->file.confdir + '/' + fdesc->gen.drvname + "-config.h");
 }
 
 void CiMainGenerator::Gen_FMonHeader()
 {
   MonGenerator mongen;
-  mongen.FillHeader((*fwriter), sigprt->sigs_expr, *fdesc);
-  fwriter->Flush(fdesc->file.fmon_h.fpath);
+  mongen.FillHeader(fwriter, sigprt.sigs_expr, *fdesc);
+  fwriter.Flush(fdesc->file.fmon_h.fpath);
 }
 
 void CiMainGenerator::Gen_FMonSource()
 {
   MonGenerator mongen;
-  mongen.FillSource((*fwriter), sigprt->sigs_expr, *fdesc);
-  fwriter->Flush(fdesc->file.fmon_c.fpath);
+  mongen.FillSource(fwriter, sigprt.sigs_expr, *fdesc);
+  fwriter.Flush(fdesc->file.fmon_c.fpath);
 }
 
 void CiMainGenerator::Gen_CanMonUtil()
 {
-  fwriter->Append("#pragma once");
-  fwriter->Append("");
-  fwriter->Append("#include <stdint.h>");
-  fwriter->Append("");
-  fwriter->Append("#ifdef __cplusplus");
-  fwriter->Append("extern \"C\" {");
-  fwriter->Append("#endif");
-  fwriter->Append("");
-  fwriter->Append("// declare here all availible checksum algorithms");
-  fwriter->Append("typedef enum");
-  fwriter->Append("{");
-  fwriter->Append("  // XOR8 = 0,");
-  fwriter->Append("  // XOR4 = 1,");
-  fwriter->Append("  // etc");
-  fwriter->Append("");
-  fwriter->Append("  // it is up to user to have or to skip final enum value - @CRC_ALG_COUNT");
-  fwriter->Append("  CRC_ALG_COUNT");
-  fwriter->Append("} DbcCanCrcMethods;");
-  fwriter->Append("");
-  fwriter->Append("typedef struct");
-  fwriter->Append("{");
-  fwriter->Append("  // @last_cycle keeps tick-value when last frame was received");
-  fwriter->Append("  uint32_t last_cycle;");
-  fwriter->Append("");
-  fwriter->Append("  // @timeout_cycle keeps maximum timeout for frame, user responsibility");
-  fwriter->Append("  // to init this field and use it in missing frame monitoring function");
-  fwriter->Append("  uint32_t timeout_cycle;");
-  fwriter->Append("");
-  fwriter->Append("  // @frame_cnt keeps count of all the received frames");
-  fwriter->Append("  uint32_t frame_cnt;");
-  fwriter->Append("");
-  fwriter->Append("  // setting up @roll_error bit indicates roll counting fail.");
-  fwriter->Append("  // Bit is not clearing automatically!");
-  fwriter->Append("  uint32_t roll_error : 1;");
-  fwriter->Append("");
-  fwriter->Append("  // setting up @checksum_error bit indicates checksum checking failure.");
-  fwriter->Append("  // Bit is not clearing automatically!");
-  fwriter->Append("  uint32_t csm_error : 1;");
-  fwriter->Append("");
-  fwriter->Append("  // setting up @cycle_error bit indicates that time was overrunned.");
-  fwriter->Append("  // Bit is not clearing automatically!");
-  fwriter->Append("  uint32_t cycle_error : 1;");
-  fwriter->Append("");
-  fwriter->Append("  // setting up @dlc_error bit indicates that the actual length of");
-  fwriter->Append("  // CAN frame is less then defined by CAN matrix!");
-  fwriter->Append("  uint32_t dlc_error : 1;");
-  fwriter->Append("");
-  fwriter->Append("} FrameMonitor_t;");
-  fwriter->Append("");
-  fwriter->Append("#ifdef __cplusplus");
-  fwriter->Append("}");
-  fwriter->Append("#endif");
-  fwriter->Append("");
+  fwriter.Append("#pragma once");
+  fwriter.Append("");
+  fwriter.Append("#include <stdint.h>");
+  fwriter.Append("");
+  fwriter.Append("#ifdef __cplusplus");
+  fwriter.Append("extern \"C\" {");
+  fwriter.Append("#endif");
+  fwriter.Append("");
+  fwriter.Append("// declare here all availible checksum algorithms");
+  fwriter.Append("typedef enum");
+  fwriter.Append("{");
+  fwriter.Append("  // XOR8 = 0,");
+  fwriter.Append("  // XOR4 = 1,");
+  fwriter.Append("  // etc");
+  fwriter.Append("");
+  fwriter.Append("  // it is up to user to have or to skip final enum value - @CRC_ALG_COUNT");
+  fwriter.Append("  CRC_ALG_COUNT");
+  fwriter.Append("} DbcCanCrcMethods;");
+  fwriter.Append("");
+  fwriter.Append("typedef struct");
+  fwriter.Append("{");
+  fwriter.Append("  // @last_cycle keeps tick-value when last frame was received");
+  fwriter.Append("  uint32_t last_cycle;");
+  fwriter.Append("");
+  fwriter.Append("  // @timeout_cycle keeps maximum timeout for frame, user responsibility");
+  fwriter.Append("  // to init this field and use it in missing frame monitoring function");
+  fwriter.Append("  uint32_t timeout_cycle;");
+  fwriter.Append("");
+  fwriter.Append("  // @frame_cnt keeps count of all the received frames");
+  fwriter.Append("  uint32_t frame_cnt;");
+  fwriter.Append("");
+  fwriter.Append("  // setting up @roll_error bit indicates roll counting fail.");
+  fwriter.Append("  // Bit is not clearing automatically!");
+  fwriter.Append("  uint32_t roll_error : 1;");
+  fwriter.Append("");
+  fwriter.Append("  // setting up @checksum_error bit indicates checksum checking failure.");
+  fwriter.Append("  // Bit is not clearing automatically!");
+  fwriter.Append("  uint32_t csm_error : 1;");
+  fwriter.Append("");
+  fwriter.Append("  // setting up @cycle_error bit indicates that time was overrunned.");
+  fwriter.Append("  // Bit is not clearing automatically!");
+  fwriter.Append("  uint32_t cycle_error : 1;");
+  fwriter.Append("");
+  fwriter.Append("  // setting up @dlc_error bit indicates that the actual length of");
+  fwriter.Append("  // CAN frame is less then defined by CAN matrix!");
+  fwriter.Append("  uint32_t dlc_error : 1;");
+  fwriter.Append("");
+  fwriter.Append("} FrameMonitor_t;");
+  fwriter.Append("");
+  fwriter.Append("#ifdef __cplusplus");
+  fwriter.Append("}");
+  fwriter.Append("#endif");
+  fwriter.Append("");
 
-  fwriter->Flush(fdesc->file.incdir + '/' + "canmonitorutil.h");
+  fwriter.Flush(fdesc->file.incdir + '/' + "canmonitorutil.h");
 }
 
 void CiMainGenerator::Gen_DbcCodeConf()
 {
-  fwriter->Append("#pragma once");
-  fwriter->Append("");
-  fwriter->Append("#include <stdint.h>");
-  fwriter->Append("");
-  fwriter->Append("// when USE_SIGFLOAT enabed the sigfloat_t must be defined");
-  fwriter->Append("// typedef double sigfloat_t;");
-  fwriter->Append("");
-  fwriter->Append("// when USE_CANSTRUCT enabled __CoderDbcCanFrame_t__ must be defined");
-  fwriter->Append("// #include \"{header_with_can_struct}\"");
-  fwriter->Append("// typedef {can_struct} __CoderDbcCanFrame_t__;");
-  fwriter->Append("");
-  fwriter->Append("// if you need to allocate rx and tx messages structs put the allocation macro here");
-  fwriter->Append("// #define __DEF_{your_driver_name}__");
-  fwriter->Append("");
+  fwriter.Append("#pragma once");
+  fwriter.Append("");
+  fwriter.Append("#include <stdint.h>");
+  fwriter.Append("");
+  fwriter.Append("// when USE_SIGFLOAT enabed the sigfloat_t must be defined");
+  fwriter.Append("// typedef double sigfloat_t;");
+  fwriter.Append("");
+  fwriter.Append("// when USE_CANSTRUCT enabled __CoderDbcCanFrame_t__ must be defined");
+  fwriter.Append("// #include \"{header_with_can_struct}\"");
+  fwriter.Append("// typedef {can_struct} __CoderDbcCanFrame_t__;");
+  fwriter.Append("");
+  fwriter.Append("// if you need to allocate rx and tx messages structs put the allocation macro here");
+  fwriter.Append("// #define __DEF_{your_driver_name}__");
+  fwriter.Append("");
 
-  fwriter->Append("// defualt @__ext_sig__ help types definition");
-  fwriter->Append("");
-  fwriter->Append("typedef uint32_t ubitext_t;");
-  fwriter->Append("typedef int32_t bitext_t;");
-  fwriter->Append("");
-  fwriter->Append("// To provide a way to make missing control correctly you");
-  fwriter->Append("// have to define macro @GetSystemTick() which has to");
-  fwriter->Append("// return kind of tick counter (e.g. 1 ms ticker)");
-  fwriter->Append("");
-  fwriter->Append("// #define GetSystemTick() __get__tick__()");
-  fwriter->Append("");
-  fwriter->Append("// To provide a way to calculate hash (crc) for CAN");
-  fwriter->Append("// frame's data field you have to define macro @GetFrameHash");
-  fwriter->Append("");
-  fwriter->Append("// #define GetFrameHash(a,b,c,d,e) __get_hash__(a,b,c,d,e)");
-  fwriter->Append("");
+  fwriter.Append("// defualt @__ext_sig__ help types definition");
+  fwriter.Append("");
+  fwriter.Append("typedef uint32_t ubitext_t;");
+  fwriter.Append("typedef int32_t bitext_t;");
+  fwriter.Append("");
+  fwriter.Append("// To provide a way to make missing control correctly you");
+  fwriter.Append("// have to define macro @GetSystemTick() which has to");
+  fwriter.Append("// return kind of tick counter (e.g. 1 ms ticker)");
+  fwriter.Append("");
+  fwriter.Append("// #define GetSystemTick() __get__tick__()");
+  fwriter.Append("");
+  fwriter.Append("// To provide a way to calculate hash (crc) for CAN");
+  fwriter.Append("// frame's data field you have to define macro @GetFrameHash");
+  fwriter.Append("");
+  fwriter.Append("// #define GetFrameHash(a,b,c,d,e) __get_hash__(a,b,c,d,e)");
+  fwriter.Append("");
 
-  fwriter->Flush(fdesc->file.confdir + '/' + "dbccodeconf.h");
+  fwriter.Flush(fdesc->file.confdir + '/' + "dbccodeconf.h");
 }
 
 void CiMainGenerator::WriteSigStructField(const SignalDescriptor_t& sig, bool bits, size_t padwidth)
 {
   if (sig.CommentText.size() > 0)
   {
-    fwriter->Append("  // " + std::regex_replace(sig.CommentText, std::regex("\n"), "\n  // "));
+    fwriter.Append("  // " + std::regex_replace(sig.CommentText, std::regex("\n"), "\n  // "));
   }
 
   if (sig.ValueText.size() > 0)
   {
-    fwriter->Append("  // " + std::regex_replace(sig.ValueText, std::regex("\n"), "\n  // "));
+    fwriter.Append("  // " + std::regex_replace(sig.ValueText, std::regex("\n"), "\n  // "));
   }
 
   if (sig.Multiplex == MultiplexType::kMulValue)
   {
-    fwriter->Append("  // multiplex variable");
+    fwriter.Append("  // multiplex variable");
   }
   else if (sig.Multiplex == MultiplexType::kMaster)
   {
-    fwriter->Append("  // MULTIPLEX master signal");
+    fwriter.Append("  // MULTIPLEX master signal");
   }
 
   std::string dtype = "";
@@ -551,14 +545,14 @@ void CiMainGenerator::WriteSigStructField(const SignalDescriptor_t& sig, bool bi
 
   dtype += pad.insert(0, padwidth + 16 - dtype.size(), ' ');
 
-  fwriter->AppendText(dtype);
+  fwriter.AppendText(dtype);
 
   pad = " // ";
   pad += (sig.Signed) ? " [-]" : "    ";
 
-  fwriter->AppendText(pad);
+  fwriter.AppendText(pad);
 
-  fwriter->AppendText(" Bits=%2d", sig.LengthBit);
+  fwriter.AppendText(" Bits=%2d", sig.LengthBit);
 
   size_t offset = 0;
   std::string infocmnt{};
@@ -603,10 +597,10 @@ void CiMainGenerator::WriteSigStructField(const SignalDescriptor_t& sig, bool bi
     infocmnt += StrPrint(" Unit:'%s'", sig.Unit.c_str());
   }
 
-  fwriter->AppendText(infocmnt);
+  fwriter.AppendText(infocmnt);
 
-  fwriter->Append("");
-  fwriter->Append();
+  fwriter.Append("");
+  fwriter.Append();
 
   if (!sig.IsSimpleSig)
   {
@@ -620,19 +614,19 @@ void CiMainGenerator::WriteSigStructField(const SignalDescriptor_t& sig, bool bi
     // own 'shadow' (_phys) copies, the problem with intermediate type (not simpe and
     // not double) is that the x = ***_toS(x) takes place in each Pack_* call
     // the signals which are not changing from Pack_* to Pack_* will change its values (!)
-    fwriter->Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
+    fwriter.Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
 
     if (sig.IsDoubleSig)
     {
-      fwriter->Append("  sigfloat_t %s;", sig.NameFloat.c_str());
+      fwriter.Append("  sigfloat_t %s;", sig.NameFloat.c_str());
     }
     else
     {
-      fwriter->Append("  %s %s;", PrintType((int)sig.TypePhys).c_str(), sig.NameFloat.c_str());
+      fwriter.Append("  %s %s;", PrintType((int)sig.TypePhys).c_str(), sig.NameFloat.c_str());
     }
 
-    fwriter->Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
+    fwriter.Append();
   }
 }
 
@@ -647,103 +641,103 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
 
     if (sgs->msg.Signals[num].Signed)
     {
-      fwriter->Append("  _m->%s = %s(( %s ), %d);",
+      fwriter.Append("  _m->%s = %s(( %s ), %d);",
         sname, ext_sig_func_name, expr.c_str(), (int32_t)sgs->msg.Signals[num].LengthBit);
     }
     else
     {
-      fwriter->Append("  _m->%s = %s;", sname, expr.c_str());
+      fwriter.Append("  _m->%s = %s;", sname, expr.c_str());
     }
 
     // print sigfloat conversion
     if (!sgs->msg.Signals[num].IsSimpleSig)
     {
-      fwriter->Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
+      fwriter.Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
 
       if (sgs->msg.Signals[num].IsDoubleSig)
       {
         // for double signals (sigfloat_t) type cast
-        fwriter->Append("  _m->%s = (sigfloat_t)(%s_%s_fromS(_m->%s));",
+        fwriter.Append("  _m->%s = (sigfloat_t)(%s_%s_fromS(_m->%s));",
           sgs->msg.Signals[num].NameFloat.c_str(), fdesc->gen.DRVNAME.c_str(), sname, sname);
       }
       else
       {
-        fwriter->Append("  _m->%s = %s_%s_fromS(_m->%s);",
+        fwriter.Append("  _m->%s = %s_%s_fromS(_m->%s);",
           sgs->msg.Signals[num].NameFloat.c_str(), fdesc->gen.DRVNAME.c_str(), sname, sname);
       }
 
-      fwriter->Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
-      fwriter->Append();
+      fwriter.Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
+      fwriter.Append();
     }
 
     else if (num + 1 == sgs->to_signals.size())
     {
       // last signal without phys part, put \n manually
-      fwriter->Append("");
+      fwriter.Append("");
     }
   }
 
-  fwriter->Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
-  fwriter->Append("  _m->mon1.dlc_error = (dlc_ < %s_DLC);", sgs->msg.Name.c_str());
-  fwriter->Append("  _m->mon1.last_cycle = GetSystemTick();");
-  fwriter->Append("  _m->mon1.frame_cnt++;");
-  fwriter->Append();
+  fwriter.Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append("  _m->mon1.dlc_error = (dlc_ < %s_DLC);", sgs->msg.Name.c_str());
+  fwriter.Append("  _m->mon1.last_cycle = GetSystemTick();");
+  fwriter.Append("  _m->mon1.frame_cnt++;");
+  fwriter.Append();
 
   if (sgs->msg.RollSig != nullptr)
   {
     // Put rolling monitor here
-    fwriter->Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
-    fwriter->Append("  _m->mon1.roll_error = (_m->%s != _m->%s_expt);",
+    fwriter.Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
+    fwriter.Append("  _m->mon1.roll_error = (_m->%s != _m->%s_expt);",
       sgs->msg.RollSig->Name.c_str(), sgs->msg.RollSig->Name.c_str());
-    fwriter->Append("  _m->%s_expt = (_m->%s + 1) & (0x%02XU);", sgs->msg.RollSig->Name.c_str(),
+    fwriter.Append("  _m->%s_expt = (_m->%s + 1) & (0x%02XU);", sgs->msg.RollSig->Name.c_str(),
       sgs->msg.RollSig->Name.c_str(), (1 << sgs->msg.RollSig->LengthBit) - 1);
     // Put rolling monitor here
-    fwriter->Append("#endif // %s", fdesc->gen.useroll_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.useroll_def.c_str());
+    fwriter.Append();
   }
 
   if (sgs->msg.CsmSig != nullptr)
   {
     // Put checksum check function call here
-    fwriter->Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
-    fwriter->Append("  _m->mon1.csm_error = (((uint8_t)GetFrameHash(_d, %s_DLC, %s_CANID, %s, %d)) != (_m->%s));",
+    fwriter.Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append("  _m->mon1.csm_error = (((uint8_t)GetFrameHash(_d, %s_DLC, %s_CANID, %s, %d)) != (_m->%s));",
       sgs->msg.Name.c_str(), sgs->msg.Name.c_str(), sgs->msg.CsmMethod.c_str(),
       sgs->msg.CsmOp, sgs->msg.CsmSig->Name.c_str());
-    fwriter->Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append();
   }
 
   auto Fmon_func = "FMon_" + sgs->msg.Name + "_" + fdesc->gen.drvname;
 
-  fwriter->Append("  %s(&_m->mon1, %s_CANID);", Fmon_func.c_str(), sgs->msg.Name.c_str());
+  fwriter.Append("  %s(&_m->mon1, %s_CANID);", Fmon_func.c_str(), sgs->msg.Name.c_str());
 
-  fwriter->Append("#endif // %s", fdesc->gen.usemon_def.c_str());
-  fwriter->Append();
+  fwriter.Append("#endif // %s", fdesc->gen.usemon_def.c_str());
+  fwriter.Append();
 
-  fwriter->Append("  return %s_CANID;", sgs->msg.Name.c_str());
+  fwriter.Append("  return %s_CANID;", sgs->msg.Name.c_str());
 }
 
 void CiMainGenerator::WritePackStructBody(const CiExpr_t* sgs)
 {
-  fwriter->Append("{");
+  fwriter.Append("{");
   PrintPackCommonText("cframe->Data", sgs);
-  fwriter->Append("  cframe->MsgId = %s_CANID;", sgs->msg.Name.c_str());
-  fwriter->Append("  cframe->DLC = %s_DLC;", sgs->msg.Name.c_str());
-  fwriter->Append("  cframe->IDE = %s_IDE;", sgs->msg.Name.c_str());
-  fwriter->Append("  return %s_CANID;", sgs->msg.Name.c_str());
-  fwriter->Append("}");
-  fwriter->Append();
+  fwriter.Append("  cframe->MsgId = %s_CANID;", sgs->msg.Name.c_str());
+  fwriter.Append("  cframe->DLC = %s_DLC;", sgs->msg.Name.c_str());
+  fwriter.Append("  cframe->IDE = %s_IDE;", sgs->msg.Name.c_str());
+  fwriter.Append("  return %s_CANID;", sgs->msg.Name.c_str());
+  fwriter.Append("}");
+  fwriter.Append();
 }
 
 void CiMainGenerator::WritePackArrayBody(const CiExpr_t* sgs)
 {
-  fwriter->Append("{");
+  fwriter.Append("{");
   PrintPackCommonText("_d", sgs);
-  fwriter->Append("  *_len = %s_DLC;", sgs->msg.Name.c_str());
-  fwriter->Append("  *_ide = %s_IDE;", sgs->msg.Name.c_str());
-  fwriter->Append("  return %s_CANID;", sgs->msg.Name.c_str());
-  fwriter->Append("}");
-  fwriter->Append();
+  fwriter.Append("  *_len = %s_DLC;", sgs->msg.Name.c_str());
+  fwriter.Append("  *_ide = %s_IDE;", sgs->msg.Name.c_str());
+  fwriter.Append("  return %s_CANID;", sgs->msg.Name.c_str());
+  fwriter.Append("}");
+  fwriter.Append();
 }
 
 void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExpr_t* sgs)
@@ -752,47 +746,47 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
   // which is differs only by arra var name
 
   // pring array content clearin loop
-  fwriter->Append("  uint8_t i; for (i = 0; (i < %s_DLC) && (i < 8); %s[i++] = 0);",
+  fwriter.Append("  uint8_t i; for (i = 0; (i < %s_DLC) && (i < 8); %s[i++] = 0);",
     sgs->msg.Name.c_str(), arrtxt.c_str());
-  fwriter->Append();
+  fwriter.Append();
 
   if (sgs->msg.RollSig != nullptr)
   {
-    fwriter->Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
-    fwriter->Append("  _m->%s = (_m->%s + 1) & (0x%02XU);", sgs->msg.RollSig->Name.c_str(),
+    fwriter.Append("#ifdef %s", fdesc->gen.useroll_def.c_str());
+    fwriter.Append("  _m->%s = (_m->%s + 1) & (0x%02XU);", sgs->msg.RollSig->Name.c_str(),
       sgs->msg.RollSig->Name.c_str(), (1 << sgs->msg.RollSig->LengthBit) - 1);
-    fwriter->Append("#endif // %s", fdesc->gen.useroll_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.useroll_def.c_str());
+    fwriter.Append();
   }
 
   if (sgs->msg.CsmSig != nullptr)
   {
     // code for clearing checksum
-    fwriter->Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
-    fwriter->Append("  _m->%s = 0U;", sgs->msg.CsmSig->Name.c_str());
-    fwriter->Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append("  _m->%s = 0U;", sgs->msg.CsmSig->Name.c_str());
+    fwriter.Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append();
   }
 
   if (sgs->msg.hasPhys)
   {
     // first step is to put code for sigfloat conversion, before
     // sigint packing to bytes.
-    fwriter->Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
+    fwriter.Append("#ifdef %s", fdesc->gen.usesigfloat_def.c_str());
 
     for (size_t n = 0; n < sgs->to_signals.size(); n++)
     {
       if (sgs->msg.Signals[n].IsSimpleSig == false)
       {
         // print toS from *_phys to original named sigint (integer duplicate of signal)
-        fwriter->Append("  _m->%s = %s_%s_toS(_m->%s);",
+        fwriter.Append("  _m->%s = %s_%s_toS(_m->%s);",
           sgs->msg.Signals[n].Name.c_str(), fdesc->gen.DRVNAME.c_str(),
           sgs->msg.Signals[n].Name.c_str(), sgs->msg.Signals[n].NameFloat.c_str());
       }
     }
 
-    fwriter->Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
+    fwriter.Append();
   }
 
   for (size_t i = 0; i < sgs->to_bytes.size(); i++)
@@ -802,24 +796,24 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
       continue;
     }
 
-    fwriter->Append("  %s[%d] |= %s;", arrtxt.c_str(), i, sgs->to_bytes[i].c_str());
+    fwriter.Append("  %s[%d] |= %s;", arrtxt.c_str(), i, sgs->to_bytes[i].c_str());
   }
 
-  fwriter->Append("");
+  fwriter.Append("");
 
   if (sgs->msg.CsmSig != nullptr)
   {
     // code for getting checksum value and putting it in array
-    fwriter->Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append("#ifdef %s", fdesc->gen.usecsm_def.c_str());
 
-    fwriter->Append("  _m->%s = ((uint8_t)GetFrameHash(%s, %s_DLC, %s_CANID, %s, %d));",
+    fwriter.Append("  _m->%s = ((uint8_t)GetFrameHash(%s, %s_DLC, %s_CANID, %s, %d));",
       sgs->msg.CsmSig->Name.c_str(), arrtxt.c_str(), sgs->msg.Name.c_str(),
       sgs->msg.Name.c_str(), sgs->msg.CsmMethod.c_str(), sgs->msg.CsmOp);
 
-    fwriter->Append("  %s[%d] |= %s;", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
+    fwriter.Append("  %s[%d] |= %s;", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
 
-    fwriter->Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
-    fwriter->Append();
+    fwriter.Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
+    fwriter.Append();
   }
 }
 

--- a/src/codegen/c-main-generator.h
+++ b/src/codegen/c-main-generator.h
@@ -10,8 +10,6 @@
 
 class CiMainGenerator {
  public:
-  CiMainGenerator();
-
   void Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd);
 
  private:
@@ -32,7 +30,7 @@ class CiMainGenerator {
   void PrintPackCommonText(const std::string& arrtxt, const CiExpr_t* sgs);
 
  private:
-  std::unique_ptr<CSigPrinter> sigprt;
-  std::unique_ptr<FileWriter> fwriter;
+  CSigPrinter sigprt;
+  FileWriter fwriter;
   const AppSettings_t* fdesc;
 };

--- a/src/codegen/c-sigprinter.cpp
+++ b/src/codegen/c-sigprinter.cpp
@@ -209,12 +209,20 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
   int32_t bbc = (startb % 8) + 1;
   int32_t slen = sig->LengthBit;
 
+  std::string multiplexPrefix = "";
+  std::string multiplexSuffix = "";
+  if (sig->Multiplex == MultiplexType::kMulValue)
+  {
+      multiplexPrefix = "((_m->" + sig->MultiplexName + " == " + std::to_string(sig->MultiplexGroup) + ") ? ";
+      multiplexSuffix = " : 0x0)";
+  }
+
   if (bbc > slen)
   {
     snprintf(workbuff, WBUFF_LEN, "((_d[%d] >> %d) & (%s))", bn, bbc - slen, msk[slen].c_str());
     tosigexpr += workbuff;
 
-    snprintf(workbuff, WBUFF_LEN, "((_m->%s & (%s)) << %d)", sig->Name.c_str(), msk[slen].c_str(), bbc - slen);
+    snprintf(workbuff, WBUFF_LEN, "%s((_m->%s & (%s)) << %d)%s", multiplexPrefix.c_str(), sig->Name.c_str(), msk[slen].c_str(), bbc - slen, multiplexSuffix.c_str());
     AppendToByteLine(to_bytes[bn], workbuff);
   }
   else if (bbc == slen)
@@ -223,7 +231,7 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
     snprintf(workbuff, WBUFF_LEN, "(_d[%d] & (%s))", bn, msk[slen].c_str());
     tosigexpr += workbuff;
 
-    snprintf(workbuff, WBUFF_LEN, "(_m->%s & (%s))", sig->Name.c_str(), msk[slen].c_str());
+    snprintf(workbuff, WBUFF_LEN, "%s(_m->%s & (%s))%s", multiplexPrefix.c_str(), sig->Name.c_str(), msk[slen].c_str(), multiplexSuffix.c_str());
     AppendToByteLine(to_bytes[bn], workbuff);
   }
   else
@@ -239,7 +247,7 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
     snprintf(workbuff, WBUFF_LEN, "(%s(_d[%d] & (%s)) << %d)", t64.c_str(), bn, msk[bbc].c_str(), slen);
     tosigexpr += workbuff;
 
-    snprintf(workbuff, WBUFF_LEN, "((_m->%s >> %d) & (%s))", sig->Name.c_str(), slen, msk[bbc].c_str());
+    snprintf(workbuff, WBUFF_LEN, "%s((_m->%s >> %d) & (%s))%s", multiplexPrefix.c_str(), sig->Name.c_str(), slen, msk[bbc].c_str(), multiplexSuffix.c_str());
     AppendToByteLine(to_bytes[bn], workbuff);
 
     while ((slen - 8) >= 0)
@@ -266,7 +274,7 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
         snprintf(workbuff, WBUFF_LEN, "(_d[%d] & (%s))", bn, msk[8].c_str());
         tosigexpr += workbuff;
 
-        snprintf(workbuff, WBUFF_LEN, "(_m->%s & (%s))", sig->Name.c_str(), msk[8].c_str());
+        snprintf(workbuff, WBUFF_LEN, "%s(_m->%s & (%s))%s", multiplexPrefix.c_str(), sig->Name.c_str(), msk[8].c_str(), multiplexSuffix.c_str());
         AppendToByteLine(to_bytes[bn], workbuff);
 
       }
@@ -280,7 +288,7 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
         snprintf(workbuff, WBUFF_LEN, "(%s(_d[%d] & (%s)) << %d)", t64.c_str(), bn, msk[8].c_str(), slen);
         tosigexpr += workbuff;
 
-        snprintf(workbuff, WBUFF_LEN, "((_m->%s >> %d) & (%s))", sig->Name.c_str(), slen, msk[8].c_str());
+        snprintf(workbuff, WBUFF_LEN, "%s((_m->%s >> %d) & (%s))%s", multiplexPrefix.c_str(), sig->Name.c_str(), slen, msk[8].c_str(), multiplexSuffix.c_str());
         AppendToByteLine(to_bytes[bn], workbuff);
       }
     }
@@ -292,8 +300,7 @@ std::string CSigPrinter::PrintSignalExpr(const SignalDescriptor_t* sig, std::vec
       snprintf(workbuff, WBUFF_LEN, " | ((_d[%d] >> %d) & (%s))", bn, 8 - slen, msk[slen].c_str());
       tosigexpr += workbuff;
 
-      snprintf(workbuff, WBUFF_LEN, "((_m->%s & (%s)) << %d)", sig->Name.c_str(), msk[slen].c_str(),
-        8 - slen);
+      snprintf(workbuff, WBUFF_LEN, "%s((_m->%s & (%s)) << %d)%s",multiplexPrefix.c_str(), sig->Name.c_str(), msk[slen].c_str(), 8 - slen, multiplexSuffix.c_str());
       AppendToByteLine(to_bytes[bn], workbuff);
     }
   }

--- a/src/codegen/c-util-generator.cpp
+++ b/src/codegen/c-util-generator.cpp
@@ -14,8 +14,6 @@ static const std::string closeguard = "#ifdef __cplusplus\n\
 CiUtilGenerator::CiUtilGenerator()
 {
   Clear();
-  tof = std::make_unique<FileWriter>();
-  condtree = std::make_unique<ConditionalTree>();
 }
 
 void CiUtilGenerator::Clear()
@@ -96,140 +94,140 @@ void CiUtilGenerator::Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd
 
 void CiUtilGenerator::PrintHeader()
 {
-  tof->Flush();
+  tof.Flush();
 
   if (gdesc->start_info.size() > 0)
   {
-    tof->Append("// " + std::regex_replace(gdesc->start_info, std::regex("\n"), "\n// "));
+    tof.Append("// " + std::regex_replace(gdesc->start_info, std::regex("\n"), "\n// "));
   }
 
-  tof->Append("#pragma once");
-  tof->Append();
+  tof.Append("#pragma once");
+  tof.Append();
 
-  tof->Append(openguard);
-  tof->Append();
+  tof.Append(openguard);
+  tof.Append();
 
   // include common dbc code config header
-  tof->Append("#include <dbccodeconf.h>");
-  tof->Append();
+  tof.Append("#include <dbccodeconf.h>");
+  tof.Append();
 
   // include c-main driver header
-  tof->Append("#include <%s.h>", file_drvname.c_str());
-  tof->Append();
+  tof.Append("#include <%s.h>", file_drvname.c_str());
+  tof.Append();
 
 
   if (rx.size() == 0)
   {
-    tof->Append("// There is no any RX mapped massage.");
-    tof->Append();
+    tof.Append("// There is no any RX mapped massage.");
+    tof.Append();
   }
   else
   {
     // print the typedef
-    tof->Append("typedef struct\n{");
+    tof.Append("typedef struct\n{");
 
     for (auto m : rx)
     {
-      tof->Append("  %s_t %s;", m->Name.c_str(), m->Name.c_str());
+      tof.Append("  %s_t %s;", m->Name.c_str(), m->Name.c_str());
     }
 
-    tof->Append("} %s_rx_t;", gdesc->drvname.c_str());
-    tof->Append();
+    tof.Append("} %s_rx_t;", gdesc->drvname.c_str());
+    tof.Append();
   }
 
   if (tx.size() == 0)
   {
-    tof->Append("// There is no any TX mapped massage.");
-    tof->Append();
+    tof.Append("// There is no any TX mapped massage.");
+    tof.Append();
   }
   else
   {
     // print the typedef
-    tof->Append("typedef struct\n{");
+    tof.Append("typedef struct\n{");
 
     for (auto m : tx)
     {
-      tof->Append("  %s_t %s;", m->Name.c_str(), m->Name.c_str());
+      tof.Append("  %s_t %s;", m->Name.c_str(), m->Name.c_str());
     }
 
-    tof->Append("} %s_tx_t;", gdesc->drvname.c_str());
-    tof->Append();
+    tof.Append("} %s_tx_t;", gdesc->drvname.c_str());
+    tof.Append();
   }
 
   if (rx.size() > 0)
   {
     // receive function necessary only when more than 0 rx messages were mapped
-    tof->Append("uint32_t %s_Receive(%s_rx_t* m, const uint8_t* d, uint32_t msgid, uint8_t dlc);",
+    tof.Append("uint32_t %s_Receive(%s_rx_t* m, const uint8_t* d, uint32_t msgid, uint8_t dlc);",
       gdesc->drvname.c_str(), gdesc->drvname.c_str());
-    tof->Append();
+    tof.Append();
   }
 
   // print extern for super structs
   if (rx.size() > 0 || tx.size() > 0)
   {
-    tof->Append("#ifdef __DEF_%s__", gdesc->DRVNAME.c_str());
-    tof->Append();
+    tof.Append("#ifdef __DEF_%s__", gdesc->DRVNAME.c_str());
+    tof.Append();
 
     if (rx.size() > 0)
     {
-      tof->Append("extern %s_rx_t %s_rx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
-      tof->Append();
+      tof.Append("extern %s_rx_t %s_rx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
+      tof.Append();
     }
 
     if (tx.size() > 0)
     {
-      tof->Append("extern %s_tx_t %s_tx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
-      tof->Append();
+      tof.Append("extern %s_tx_t %s_tx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
+      tof.Append();
     }
 
-    tof->Append("#endif // __DEF_%s__", gdesc->DRVNAME.c_str());
-    tof->Append();
+    tof.Append("#endif // __DEF_%s__", gdesc->DRVNAME.c_str());
+    tof.Append();
   }
 
-  tof->Append(closeguard);
+  tof.Append(closeguard);
 
-  tof->Flush(fdesc->util_h.fpath);
+  tof.Flush(fdesc->util_h.fpath);
 }
 
 void CiUtilGenerator::PrintSource()
 {
   if (gdesc->start_info.size() > 0)
   {
-    tof->Append("// " + std::regex_replace(gdesc->start_info, std::regex("\n"), "\n// "));
+    tof.Append("// " + std::regex_replace(gdesc->start_info, std::regex("\n"), "\n// "));
   }
 
-  tof->Append("#include \"%s\"", fdesc->util_h.fname.c_str());
-  tof->Append();
+  tof.Append("#include \"%s\"", fdesc->util_h.fname.c_str());
+  tof.Append();
 
-  tof->Append("// DBC file version");
-  tof->Append("#if (%s != (%uU)) || (%s != (%uU))",
+  tof.Append("// DBC file version");
+  tof.Append("#if (%s != (%uU)) || (%s != (%uU))",
     gdesc->verhigh_def.c_str(), p_dlist->ver.hi, gdesc->verlow_def.c_str(), p_dlist->ver.low);
 
-  tof->Append("#error The %s binutil source file has inconsistency with core dbc lib!",
+  tof.Append("#error The %s binutil source file has inconsistency with core dbc lib!",
     gdesc->DRVNAME.c_str());
-  tof->Append("#endif");
-  tof->Append();
+  tof.Append("#endif");
+  tof.Append();
 
   // optional RX and TX struct allocations
   if (rx.size() > 0 || tx.size() > 0)
   {
-    tof->Append("#ifdef __DEF_%s__", gdesc->DRVNAME.c_str());
-    tof->Append();
+    tof.Append("#ifdef __DEF_%s__", gdesc->DRVNAME.c_str());
+    tof.Append();
 
     if (rx.size() > 0)
     {
-      tof->Append("%s_rx_t %s_rx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
-      tof->Append();
+      tof.Append("%s_rx_t %s_rx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
+      tof.Append();
     }
 
     if (tx.size() > 0)
     {
-      tof->Append("%s_tx_t %s_tx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
-      tof->Append();
+      tof.Append("%s_tx_t %s_tx;", gdesc->drvname.c_str(), gdesc->drvname.c_str());
+      tof.Append();
     }
 
-    tof->Append("#endif // __DEF_%s__", gdesc->DRVNAME.c_str());
-    tof->Append();
+    tof.Append("#endif // __DEF_%s__", gdesc->DRVNAME.c_str());
+    tof.Append();
   }
 
   if (rx.size() > 0)
@@ -240,26 +238,26 @@ void CiUtilGenerator::PrintSource()
     // binary search on FrameID for selecting unpacking function
     auto tree = FillTreeLevel(rx, 0, static_cast<int32_t>(rx.size()));
 
-    tof->Append("uint32_t %s_Receive(%s_rx_t* _m, const uint8_t* _d, uint32_t _id, uint8_t dlc_)",
+    tof.Append("uint32_t %s_Receive(%s_rx_t* _m, const uint8_t* _d, uint32_t _id, uint8_t dlc_)",
       gdesc->drvname.c_str(), gdesc->drvname.c_str());
 
-    tof->Append("{");
-    tof->Append(" uint32_t recid = 0;");
+    tof.Append("{");
+    tof.Append(" uint32_t recid = 0;");
 
     // put tree-view struct on code (in treestr variable)
     std::string treestr;
-    condtree->Clear();
-    tof->Append(condtree->WriteCode(tree, treestr, 1));
-    tof->Append();
-    tof->Append(" return recid;");
-    tof->Append("}");
-    tof->Append();
+    condtree.Clear();
+    tof.Append(condtree.WriteCode(tree, treestr, 1));
+    tof.Append();
+    tof.Append(" return recid;");
+    tof.Append("}");
+    tof.Append();
 
     // clear tree after using
-    condtree->DeleteTree(tree);
+    condtree.DeleteTree(tree);
   }
 
-  tof->Flush(fdesc->util_c.fpath);
+  tof.Flush(fdesc->util_c.fpath);
 }
 
 ConditionalTree_t* CiUtilGenerator::FillTreeLevel(std::vector<MessageDescriptor_t*>& list,

--- a/src/codegen/c-util-generator.h
+++ b/src/codegen/c-util-generator.h
@@ -37,8 +37,8 @@ class CiUtilGenerator {
   std::vector<MessageDescriptor_t*> both;
 
   // to file writer
-  std::unique_ptr<FileWriter> tof;
-  std::unique_ptr<ConditionalTree> condtree;
+  FileWriter tof;
+  ConditionalTree condtree;
 
   std::string code_drvname;
   std::string file_drvname;

--- a/src/maincli.cpp
+++ b/src/maincli.cpp
@@ -8,6 +8,6 @@ int main(int argc, char* argv[])
 {
   OptionsParser parser;
   auto opts = parser.GetOptions(argc, argv);
-  auto app = std::make_unique<CoderApp>(opts);
-  app->Run();
+  CoderApp app(opts);
+  app.Run();
 }

--- a/src/options-parser.cpp
+++ b/src/options-parser.cpp
@@ -1,14 +1,15 @@
 #include "options-parser.h"
 #include "helpers/formatter.h"
 
-OptionsParser::Pairs OptionsParser::GetOptions(int argc, char** argv)
+OptionsParser::GenOptions OptionsParser::GetOptions(int argc, char** argv)
 {
-  std::vector<OnePair> ret{};
+  using onepair_t = std::pair<std::string, std::string>;
 
-  OnePair pair{};
+  std::vector<onepair_t> temppairs{};
+  onepair_t pair{};
+  GenOptions retpairs{};
 
-  Pairs pairs{};
-
+  // collect arguments/values to vector
   for (int i = 0; i < argc; i++)
   {
     // key found (must start with '-' (e.g. '-dbc'))
@@ -17,65 +18,67 @@ OptionsParser::Pairs OptionsParser::GetOptions(int argc, char** argv)
       pair.first = std::string(argv[i]);
       pair.second.clear();
 
-      if ((i + 1) < argc && argv[i + 1][0] != '-')
+      size_t valindex = i + 1;
+
+      if ((valindex < argc) && (argv[valindex][0] != '-'))
       {
         // key param
-        pair.second = std::string(argv[i + 1]);
-        // unlooped i incremention
+        pair.second = std::string(argv[valindex]);
+        // shift position to next key
         ++i;
       }
 
-      ret.push_back(pair);
+      temppairs.push_back(pair);
     }
   }
 
-  for (size_t i = 0; i < ret.size(); i++)
+  for (size_t i = 0; i < temppairs.size(); i++)
   {
-    if (ret[i].first.compare("-dbc") == 0)
+    if (temppairs[i].first.compare("-dbc") == 0)
     {
-      pairs.dbc.value = ret[i].second;
-      pairs.dbc.ok = true;
+      retpairs.dbc.first = temppairs[i].second;
+      retpairs.dbc.second = true;
     }
-    else if (ret[i].first.compare("-out") == 0)
+    else if (temppairs[i].first.compare("-out") == 0)
     {
-      pairs.outdir.value = ret[i].second;
-      pairs.outdir.ok = true;
+      retpairs.outdir.first = temppairs[i].second;
+      retpairs.outdir.second = true;
     }
-    else if (ret[i].first.compare("-drvname") == 0)
+    else if (temppairs[i].first.compare("-drvname") == 0)
     {
-      pairs.drvname.value = make_c_name(ret[i].second);
-      pairs.drvname.ok = true;
+      retpairs.drvname.first = make_c_name(temppairs[i].second);
+      retpairs.drvname.second = true;
 
-      if (pairs.drvname.value.length() == 0)
+      if (retpairs.drvname.first.length() == 0)
       {
-        pairs.drvname.ok = false;
+        retpairs.drvname.second = false;
       }
     }
-    else if (ret[i].first.compare("-rw") == 0)
+    else if (temppairs[i].first.compare("-rw") == 0)
     {
-      pairs.is_rewrite = true;
+      retpairs.is_rewrite = true;
     }
-    else if (ret[i].first.compare("-nodeutils") == 0)
+    else if (temppairs[i].first.compare("-nodeutils") == 0)
     {
-      pairs.is_nodeutils = true;
+      retpairs.is_nodeutils = true;
     }
-    else if (ret[i].first.compare("-help") == 0)
+    else if (temppairs[i].first.compare("-help") == 0)
     {
-      pairs.is_help = true;
+      retpairs.is_help = true;
     }
-    else if (ret[i].first.compare("-noinc") == 0)
+    else if (temppairs[i].first.compare("-noinc") == 0)
     {
-      pairs.is_nocanmon = true;
+      retpairs.is_nocanmon = true;
     }
-    else if (ret[i].first.compare("-noconfig") == 0)
+    else if (temppairs[i].first.compare("-noconfig") == 0)
     {
-      pairs.is_noconfig = true;
+      retpairs.is_noconfig = true;
     }
-    else if (ret[i].first.compare("-nofmon") == 0)
+    else if (temppairs[i].first.compare("-nofmon") == 0)
     {
-      pairs.is_nofmon = true;
+      retpairs.is_nofmon = true;
     }
   }
 
-  return pairs;
+  return retpairs;
 }

--- a/src/options-parser.h
+++ b/src/options-parser.h
@@ -1,36 +1,54 @@
 #pragma once
 
+#include <memory>
 #include <stdlib.h>
 #include <string>
-#include <memory>
+#include <utility>
 #include <vector>
 
-typedef struct
-{
-  std::string value;
-  bool ok{false};
-} StrParam_t;
-
-typedef struct
-{
-  StrParam_t dbc;
-  StrParam_t outdir;
-  StrParam_t drvname;
-  bool is_rewrite{false};
-  bool is_nodeutils{false};
-  bool is_noconfig{false};
-  bool is_nocanmon{false};
-  bool is_nofmon{false};
-  bool is_help{false};
-} ParamConfig_t;
-
+/// @brief CLI arguments parser
 class OptionsParser {
  public:
 
-  using OnePair = std::pair<std::string, std::string>;
-  using Pairs = ParamConfig_t;
+  /// @brief key/value type wrapper
+  using dualparam_t = std::pair<std::string, bool>;
 
-  ParamConfig_t GetOptions(int argc, char** argv);
+  /// @brief Arguments description struct
+  struct GenOptions
+  {
+    /// @brief dbc file name
+    dualparam_t dbc;
+
+    /// @brief output directory for generated files
+    dualparam_t outdir;
+
+    /// @brief main driver name
+    dualparam_t drvname;
+
+    /// @brief rewrite previously generated files or generate to next subdirectory
+    bool is_rewrite{false};
+
+    /// @brief generate specific utility drivers for each ECU defined in the matrix
+    bool is_nodeutils{false};
+
+    /// @brief do not generate configuration file
+    bool is_noconfig{false};
+
+    /// @brief do not generate canmonitorutil header
+    bool is_nocanmon{false};
+
+    /// @brief do not generate fmon header
+    bool is_nofmon{false};
+
+    /// @brief help is requested
+    bool is_help{false};
+  };
+
+  /// @brief Parses arguments and theirs optional values
+  /// @param argc arguments number
+  /// @param argv pointer to array with arguments
+  /// @return parsed arguments in structured form
+  GenOptions GetOptions(int argc, char** argv);
 
 };
 

--- a/src/parser/dbclineparser.cpp
+++ b/src/parser/dbclineparser.cpp
@@ -178,7 +178,7 @@ bool DbcLineParser::IsSignalLine(const std::string& line)
   return ret;
 }
 
-bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& line)
+bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& line, std::string& sigMultiplexMasterName)
 {
   // split line in two parts
   auto halfs = resplit(line, kRegSigSplit1, -1);
@@ -200,6 +200,7 @@ bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& 
   {
     sig->Name = halfs[1];
     sig->Multiplex = MultiplexType::kNone;
+    sig->MultiplexGroup = 0;
 
     if (halfs.size() == 3)
     {
@@ -207,10 +208,15 @@ bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& 
       if (halfs[2] == "M")
       {
         sig->Multiplex = MultiplexType::kMaster;
+        sigMultiplexMasterName = sig->Name;
       }
       else
       {
         sig->Multiplex = MultiplexType::kMulValue;
+        sig->MultiplexName = sigMultiplexMasterName;
+        // get multiplex group from string m<group number>
+        // convert string starting at index 1 (not zero) to int        
+        sig->MultiplexGroup = std::stoi(halfs[2].substr(1, halfs[2].size()-1));
       }
     }
   }

--- a/src/parser/dbclineparser.h
+++ b/src/parser/dbclineparser.h
@@ -48,13 +48,15 @@ class DbcLineParser {
 
   // checks if the line is message description
   bool IsMessageLine(const std::string& line);
+  
   // parses message line
   bool ParseMessageLine(MessageDescriptor_t* msg, const std::string& line = "");
 
   // checks if the line is signal description
   bool IsSignalLine(const std::string& line);
+
   // parses signal line
-  bool ParseSignalLine(SignalDescriptor_t* sig, const std::string& line);
+  bool ParseSignalLine(SignalDescriptor_t *sig, const std::string &line, std::string& sigMultiplexMasterName);
 
   // tries to parse attribute line (or a few lines) and
   // loads result in attr struct, return @true if parsed ok

--- a/src/parser/dbcscanner.cpp
+++ b/src/parser/dbcscanner.cpp
@@ -66,6 +66,8 @@ void DbcScanner::ParseMessageInfo(istream& readstrm)
 
   MessageDescriptor_t* pMsg = nullptr;
 
+  std::string sigMultiplexMasterName;
+
   while (readstrm.eof() == false)
   {
     std::getline(readstrm, sline);
@@ -97,7 +99,7 @@ void DbcScanner::ParseMessageInfo(istream& readstrm)
       SignalDescriptor_t sig;
 
       // parse signal line
-      if (lparser.ParseSignalLine(&sig, sline))
+      if (lparser.ParseSignalLine(&sig, sline, sigMultiplexMasterName))
       {
         // put successfully parsed  signal to the message signals
         pMsg->Signals.push_back(sig);

--- a/src/tests/args-test.cpp
+++ b/src/tests/args-test.cpp
@@ -18,16 +18,16 @@ TEST(ArgParserTest, BasicAssert)
   OptionsParser parser;
   auto ret = parser.GetOptions(9, testchunks);
 
-  expect_true(ret.dbc.ok);
-  expect_true(ret.dbc.value.compare("path/to/test.dbc") == 0);
+  expect_true(ret.dbc.second);
+  expect_true(ret.dbc.first.compare("path/to/test.dbc") == 0);
 
-  expect_true(ret.outdir.ok);
-  expect_true(ret.outdir.value.compare("path/to/out") == 0);
+  expect_true(ret.outdir.second);
+  expect_true(ret.outdir.first.compare("path/to/out") == 0);
 
-  expect_true(ret.drvname.ok);
-  expect_true(ret.drvname.value.compare("testdbc") == 0);
+  expect_true(ret.drvname.second);
+  expect_true(ret.drvname.first.compare("testdbc") == 0);
+
   expect_true(ret.is_rewrite);
-
   expect_false(ret.is_help);
   expect_false(ret.is_noconfig);
   expect_false(ret.is_nodeutils);

--- a/src/types/attributes.h
+++ b/src/types/attributes.h
@@ -4,21 +4,24 @@
 #include <vector>
 #include <string>
 
+/// @brief Message attributes
 enum class AttributeType
 {
+  /// @brief Message cycle time attribute
   CycleTime,
+
+  /// @brief Undefined attribute
   Undefined
 };
 
-typedef struct
+struct AttributeDescriptor_t
 {
-  // message id of the attribute
+  /// @brief Attribute message ID
   uint32_t MsgId;
 
-  // value of the comment from line
+  /// @brief Attribute type
   AttributeType Type;
 
-  // attribute value
+  /// @brief Attribute value
   int32_t Value;
-
-} AttributeDescriptor_t;
+};

--- a/src/types/comment.h
+++ b/src/types/comment.h
@@ -4,36 +4,42 @@
 #include <string>
 #include <vector>
 
+/// @brief Type of commented value
 enum class CommentTarget
 {
+  /// @brief Comment is for CAN message
   Message,
+  /// @brief Comment is for CAN message signal
   Signal,
+  /// @brief Invalid type
   Undefined
 };
 
-typedef struct
-{
 
-  // CAN ID to which comment is belongs (in case of message targeting)
+/// @brief Comment descripton
+struct Comment_t
+{
+  /// @brief Message ID for which comment is bound
   uint32_t MsgId;
 
-  // name of signal of the CAN Frame to whick comment is belong (in case
-  // of signal targeting
+  /// @brief Signal name for which comment is bound
   std::string SigName;
 
-  // type of the comment in attribute line (message or signal)
+  /// @brief Comment target type
   CommentTarget ca_target;
 
-  // value of the comment from line
+  /// @brief Comment text
   std::string Text;
+};
 
-} Comment_t;
 
-
-typedef struct
+/// @brief Value table inforamtion
+struct ValTable_t
 {
+  /// @brief Signal name for which value table is applied
   std::string SigName;
 
+  /// @brief Value table names and values pairs
   std::vector<std::pair<std::string, uint32_t>> vpairs{};
 
-} ValTable_t;
+};

--- a/src/types/message.h
+++ b/src/types/message.h
@@ -89,7 +89,13 @@ typedef struct
 
   std::string ValueText;
 
+  // multiplex information
+  // type
+  // group number
+  // multiplex name
   MultiplexType Multiplex;
+  uint16_t MultiplexGroup;
+  std::string MultiplexName;
 
 } SignalDescriptor_t;
 


### PR DESCRIPTION
dbc mux feature added to parsing and printing
tests for mux added

what to consider:
With my additions to the code the multiplex index variable must be defined before a multiplexed variable in the DBC file.
If a multiplexed variable is defined/read before the multiplex index variable is read, the property MultiplexName in the SignalDescriptor wont be set at all.

[mux_test.dbc.txt](https://github.com/astand/c-coderdbc/files/11291815/mux_test.dbc.txt)
