### PR TITLE
Fix memory corruption (marker was getting overflowed because

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Coderdbc is a CLI utility for generating C code from DBC CAN matrix files
 For building project you need to have cmake and c++ development toolkit in your system
 1 download source code:
 ```sh
-git clone https://github.com/astand/c-coderdbc.git coderdbc
+git clone https://github.com/envgoinc/c-coderdbc.git coderdbc
 ```
 Go to the source code directory:
 ```sh

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -130,10 +130,10 @@ void CoderApp::GenerateCode()
       fscreator.FS.file.util_c.dir = fscreator.FS.file.utildir;
       fscreator.FS.file.util_h.dir = fscreator.FS.file.utildir;
 
-      fscreator.FS.file.util_h.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.h");
+      fscreator.FS.file.util_h.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.hpp");
       fscreator.FS.file.util_h.fpath = fscreator.FS.file.utildir + "/" + fscreator.FS.file.util_h.fname;
 
-      fscreator.FS.file.util_c.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.c");
+      fscreator.FS.file.util_c.fname = str_tolower(fscreator.FS.gen.drvname + "-binutil.cpp");
       fscreator.FS.file.util_c.fpath = fscreator.FS.file.utildir + "/" + fscreator.FS.file.util_c.fname;
 
       MsgsClassification groups;
@@ -207,8 +207,8 @@ void CoderApp::PrintHelp()
   std::cout << "   \t\t '-rw' option enables rewriting: all source files previously generated" << std::endl;
   std::cout << "   \t\t will be replaced by new ones" << std::endl;
   std::cout << "   -noconfig:\t no {drivername}-config and dbccodeconfig generation" << std::endl;
-  std::cout << "   -noinc:\t no canmonitorutil.h generation" << std::endl;
-  std::cout << "   -nofmon:\t no ***-fmon.c generation" << std::endl;
+  std::cout << "   -noinc:\t no canmonitorutil.hpp generation" << std::endl;
+  std::cout << "   -nofmon:\t no ***-fmon.cpp generation" << std::endl;
   std::cout << std::endl;
 
   std::cout << "examples:" << std::endl;

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -35,6 +35,7 @@ void CoderApp::GenerateCode()
   CiMainGenerator cigen;
   CiUtilGenerator ciugen;
   FsCreator fscreator;
+  std::string path;
 
   std::ifstream reader;
 
@@ -57,9 +58,18 @@ void CoderApp::GenerateCode()
   std::string info("");
 
   // create main destination directory
-  fscreator.Configure(Params.drvname.first, Params.outdir.first, info, scanner.dblist.ver.hi, scanner.dblist.ver.low);
+  if (!Params.is_rewrite)
+  {
+    path = fscreator.FindPath(Params.outdir.first);
+  }
+  else
+  {
+    path = Params.outdir.first;
+  }
 
-  auto ret = fscreator.PrepareDirectory(Params.is_rewrite);
+  fscreator.Configure(Params.drvname.first, path, info, scanner.dblist.ver.hi, scanner.dblist.ver.low);
+
+  auto ret = fscreator.PrepareDirectory();
 
   fscreator.FS.gen.no_config = Params.is_noconfig;
   fscreator.FS.gen.no_inc = Params.is_nocanmon;

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -110,7 +110,7 @@ void CiMainGenerator::Gen_MainHeader()
   fwriter.Append(
     "// This file must define:\n"
     "// base monitor struct\n"
-    "#include \"canmonitorutil.hpp\"\n"
+    "#include <nv1_can_gen/src/canmonitorutil.hpp>\n"
     "\n"
   );
 

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -879,4 +879,3 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
     fwriter.Append();
   }
 }
-

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -24,7 +24,7 @@ const char* extend_func_body =
   "// n+1 bits where n is the largest signed signal width. For example if\n"
   "// the most wide signed signal has a width of 31 bits you need to set\n"
   "// bitext_t as int32_t and ubitext_t as uint32_t\n"
-  "// Defined these typedefs in @dbccodeconf.h or locally in 'dbcdrvname'-config.h\n"
+  "// Defined these typedefs in @dbccodeconf.hpp or locally in 'dbcdrvname'-config.hpp\n"
   "static bitext_t %s(ubitext_t val, uint8_t bits)\n"
   "{\n"
   "  ubitext_t const m = 1u << (bits - 1);\n"
@@ -66,10 +66,10 @@ void CiMainGenerator::Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd
 
   if (!fsd.gen.no_config)
   {
-    // 6 step is to print template for drv-config.h
+    // 6 step is to print template for drv-config.hpp
     Gen_ConfigHeader();
 
-    // 8 step is to print dbccodeconf.h template
+    // 8 step is to print dbccodeconf.hpp template
     Gen_DbcCodeConf();
   }
 
@@ -93,8 +93,6 @@ void CiMainGenerator::Gen_MainHeader()
 
   fwriter.Append("#pragma once");
   fwriter.Append();
-  fwriter.Append("#ifdef __cplusplus\nextern \"C\" {\n#endif");
-  fwriter.Append();
   fwriter.Append("#include <stdint.h>");
   fwriter.Append();
 
@@ -104,7 +102,7 @@ void CiMainGenerator::Gen_MainHeader()
   fwriter.Append();
 
   fwriter.Append("// include current dbc-driver compilation config");
-  fwriter.Append("#include \"%s-config.h\"", fdesc->gen.drvname.c_str());
+  fwriter.Append("#include \"%s-config.hpp\"", fdesc->gen.drvname.c_str());
   fwriter.Append();
 
   fwriter.Append("#ifdef %s", fdesc->gen.usemon_def.c_str());
@@ -112,7 +110,7 @@ void CiMainGenerator::Gen_MainHeader()
   fwriter.Append(
     "// This file must define:\n"
     "// base monitor struct\n"
-    "#include \"canmonitorutil.h\"\n"
+    "#include \"canmonitorutil.hpp\"\n"
     "\n"
   );
 
@@ -169,10 +167,7 @@ void CiMainGenerator::Gen_MainHeader()
     fwriter.Append("#define %s_DLC (%uU)", m.Name.c_str(), m.DLC);
     fwriter.Append("#define %s_CANID (%#xU)", m.Name.c_str(), m.MsgID);
 
-    if (m.Cycle > 0)
-    {
-      fwriter.Append("#define %s_CYC (%dU)", m.Name.c_str(), m.Cycle);
-    }
+    fwriter.Append("#define %s_CYC (%dU)", m.Name.c_str(), m.Cycle);
 
     size_t max_sig_name_len = 27;
 
@@ -328,8 +323,6 @@ void CiMainGenerator::Gen_MainHeader()
     fwriter.Append();
   }
 
-  fwriter.Append("#ifdef __cplusplus\n}\n#endif");
-
   // save fwrite cached text to file
   fwriter.Flush(fdesc->file.core_h.fpath);
 }
@@ -362,7 +355,7 @@ void CiMainGenerator::Gen_MainSource()
     "// Function prototypes to be called each time CAN frame is unpacked\n"
     "// FMon function may detect RC, CRC or DLC violation\n");
 
-  fwriter.Append("#include \"%s-fmon.h\"", fdesc->gen.drvname.c_str());
+  fwriter.Append("#include \"%s-fmon.hpp\"", fdesc->gen.drvname.c_str());
   fwriter.Append();
 
   fwriter.Append("#endif // %s", fdesc->gen.usemon_def.c_str());
@@ -370,7 +363,7 @@ void CiMainGenerator::Gen_MainSource()
   fwriter.Append("// This macro guard for the case when you need to enable");
   fwriter.Append("// using diag monitors but there is no necessity in proper");
   fwriter.Append("// SysTick provider. For providing one you need define macro");
-  fwriter.Append("// before this line - in dbccodeconf.h");
+  fwriter.Append("// before this line - in dbccodeconf.hpp");
   fwriter.Append("");
   fwriter.Append("#ifndef GetSystemTick");
   fwriter.Append("#define GetSystemTick() (0u)");
@@ -452,7 +445,7 @@ void CiMainGenerator::Gen_ConfigHeader()
   ConfigGenerator confgen;
   confgen.FillHeader(fwriter, fdesc->gen);
 
-  fwriter.Flush(fdesc->file.confdir + '/' + fdesc->gen.drvname + "-config.h");
+  fwriter.Flush(fdesc->file.confdir + '/' + fdesc->gen.drvname + "-config.hpp");
 }
 
 void CiMainGenerator::Gen_FMonHeader()
@@ -474,10 +467,6 @@ void CiMainGenerator::Gen_CanMonUtil()
   fwriter.Append("#pragma once");
   fwriter.Append("");
   fwriter.Append("#include <stdint.h>");
-  fwriter.Append("");
-  fwriter.Append("#ifdef __cplusplus");
-  fwriter.Append("extern \"C\" {");
-  fwriter.Append("#endif");
   fwriter.Append("");
   fwriter.Append("// declare here all availible checksum algorithms");
   fwriter.Append("typedef enum");
@@ -520,12 +509,8 @@ void CiMainGenerator::Gen_CanMonUtil()
   fwriter.Append("");
   fwriter.Append("} FrameMonitor_t;");
   fwriter.Append("");
-  fwriter.Append("#ifdef __cplusplus");
-  fwriter.Append("}");
-  fwriter.Append("#endif");
-  fwriter.Append("");
 
-  fwriter.Flush(fdesc->file.incdir + '/' + "canmonitorutil.h");
+  fwriter.Flush(fdesc->file.incdir + '/' + "canmonitorutil.hpp");
 }
 
 void CiMainGenerator::Gen_DbcCodeConf()
@@ -562,7 +547,7 @@ void CiMainGenerator::Gen_DbcCodeConf()
   fwriter.Append("// #define GetFrameHash(a,b,c,d,e) __get_hash__(a,b,c,d,e)");
   fwriter.Append("");
 
-  fwriter.Flush(fdesc->file.confdir + '/' + "dbccodeconf.h");
+  fwriter.Flush(fdesc->file.confdir + '/' + "dbccodeconf.hpp");
 }
 
 void CiMainGenerator::WriteSigStructField(const SignalDescriptor_t& sig, bool bits, size_t padwidth)

--- a/src/codegen/c-util-generator.cpp
+++ b/src/codegen/c-util-generator.cpp
@@ -110,15 +110,12 @@ void CiUtilGenerator::PrintHeader()
   tof.Append("#pragma once");
   tof.Append();
 
-  tof.Append(openguard);
-  tof.Append();
-
   // include common dbc code config header
-  tof.Append("#include \"dbccodeconf.h\"");
+  tof.Append("#include <nv1_can_gen/src/dbccodeconf.hpp>");
   tof.Append();
 
   // include c-main driver header
-  tof.Append("#include \"%s.h\"", file_drvname.c_str());
+  tof.Append("#include \"%s.hpp\"", file_drvname.c_str());
   tof.Append();
 
 
@@ -189,8 +186,6 @@ void CiUtilGenerator::PrintHeader()
     tof.Append("#endif // __DEF_%s__", gdesc->DRVNAME.c_str());
     tof.Append();
   }
-
-  tof.Append(closeguard);
 
   tof.Flush(fdesc->util_h.fpath);
 }

--- a/src/codegen/c-util-generator.h
+++ b/src/codegen/c-util-generator.h
@@ -19,7 +19,7 @@ class CiUtilGenerator {
   // the output of this function source files which contain:
   // - global TX and RX typedefs message struct
   // - function to Unpack incoming frame to dedicated RX message struct field
-  // - optional (through define in global "dbccodeconf.h") variable allocation in source files
+  // - optional (through define in global "dbccodeconf.hpp") variable allocation in source files
   //
   void Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd,
     const MsgsClassification& groups, const std::string& drvname);

--- a/src/codegen/config-generator.cpp
+++ b/src/codegen/config-generator.cpp
@@ -5,7 +5,7 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append("#pragma once");
   wr.Append("");
   wr.Append("/* include common dbccode configurations */");
-  wr.Append("#include \"dbccodeconf.h\"");
+  wr.Append("#include <nv1_can_gen/src/dbccodeconf.hpp>");
   wr.Append("");
   wr.Append("");
   wr.Append("/* ------------------------------------------------------------------------- *");
@@ -28,7 +28,7 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append("    u8 Data[8] (CAN Frame payload data)");
   wr.Append("    u8 IDE (CAN Frame Extended (1) / Standard (0) ID type)");
   wr.Append("");
-  wr.Append("  This struct definition have to be placed (or be included) in dbccodeconf.h */");
+  wr.Append("  This struct definition have to be placed (or be included) in dbccodeconf.hpp */");
   wr.Append("");
   wr.Append("/* #define %s */", gsett.usesruct_def.c_str());
   wr.Append(2);
@@ -43,7 +43,7 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append("  1. All the '_ro' fields will have a pair field with '_phys' postfix.");
   wr.Append("  If only offset != 0 is true then the type of '_phys' signal is the same");
   wr.Append("  as '_ro' signal. In other case the type will be @sigfloat_t which");
-  wr.Append("  have to be defined in user dbccodeconf.h");
+  wr.Append("  have to be defined in user dbccodeconf.hpp");
   wr.Append("");
   wr.Append("  2. In pack function '_ro' signal will be rewritten by '_phys' signal, which");
   wr.Append("  requires from user to use ONLY '_phys' signal for packing frame");
@@ -55,7 +55,7 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append(2);
 
   wr.Append("/* ------------------------------------------------------------------------- *");
-  wr.Append("  Note(!) that the \"canmonitorutil.h\" must be accessed in include path:");
+  wr.Append("  Note(!) that the \"canmonitorutil.hpp\" must be accessed in include path:");
   wr.Append("");
   wr.Append("  This macro adds:");
   wr.Append("");
@@ -63,7 +63,7 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append("");
   wr.Append("  - capture system tick in unpack function and save value to mon1 field");
   wr.Append("  to provide to user better missing frame detection code. For this case");
-  wr.Append("  user must provide function declared in canmonitorutil.h - GetSysTick()");
+  wr.Append("  user must provide function declared in canmonitorutil.hpp - GetSysTick()");
   wr.Append("  which may return 1ms uptime.");
   wr.Append("");
   wr.Append("  - calling function FMon_***  (from 'fmon' driver) inside unpack function");
@@ -95,8 +95,8 @@ void ConfigGenerator::FillHeader(FileWriter& wr, const GenDescriptor_t& gsett)
   wr.Append("  - \"Checksum\": constant marker word");
   wr.Append("");
   wr.Append("  - \"XOR8\": type of method, this text will be passed to GetFrameHash");
-  wr.Append("  (canmonitorutil.h) function as is, the best use case is to define 'enum");
-  wr.Append("  DbcCanCrcMethods' in canmonitorutil.h file with all possible");
+  wr.Append("  (canmonitorutil.hpp) function as is, the best use case is to define 'enum");
+  wr.Append("  DbcCanCrcMethods' in canmonitorutil.hpp file with all possible");
   wr.Append("  checksum algorithms (e.g. XOR8, XOR4 etc)");
   wr.Append("");
   wr.Append("  - \"3\": optional value that will be passed to GetFrameHash as integer value");

--- a/src/codegen/fs-creator.cpp
+++ b/src/codegen/fs-creator.cpp
@@ -8,11 +8,11 @@ static const int32_t kTmpLen = 1024;
 
 static char _tmpb[kTmpLen];
 
-static const char* kLibDir = "/lib";
-static const char* kUsrDir = "/usr";
-static const char* kIncDir = "/inc";
-static const char* kConfDir = "/conf";
-static const char* kUtilDir = "/butl";
+static const char* kLibDir = "/";
+static const char* kUsrDir = "/";
+static const char* kIncDir = "/";
+static const char* kConfDir = "/";
+static const char* kUtilDir = "/";
 
 FsCreator::FsCreator()
 {
@@ -50,27 +50,27 @@ void FsCreator::Configure(const std::string& drvname, const std::string& outpath
   FS.gen.drvname = str_tolower(drvname);
 
   FS.file.core_h.dir = outpath;
-  FS.file.core_h.fname = FS.gen.drvname + ".h";
+  FS.file.core_h.fname = FS.gen.drvname + ".hpp";
   FS.file.core_h.fpath = FS.file.libdir + "/" + FS.file.core_h.fname;
 
   FS.file.core_c.dir = outpath;
-  FS.file.core_c.fname = FS.gen.drvname + ".c";
+  FS.file.core_c.fname = FS.gen.drvname + ".cpp";
   FS.file.core_c.fpath = FS.file.libdir + "/" + FS.file.core_c.fname;
 
   FS.file.util_h.dir = outpath;
-  FS.file.util_h.fname = FS.gen.drvname + "-binutil" + ".h";
+  FS.file.util_h.fname = FS.gen.drvname + "-binutil" + ".hpp";
   FS.file.util_h.fpath = FS.file.utildir + "/" + FS.file.util_h.fname;
 
   FS.file.util_c.dir = outpath;
-  FS.file.util_c.fname = FS.gen.drvname + "-binutil" + ".c";
+  FS.file.util_c.fname = FS.gen.drvname + "-binutil" + ".cpp";
   FS.file.util_c.fpath = FS.file.utildir + "/" + FS.file.util_c.fname;
 
   FS.file.fmon_h.dir = outpath;
-  FS.file.fmon_h.fname = FS.gen.drvname + "-fmon.h";
+  FS.file.fmon_h.fname = FS.gen.drvname + "-fmon.hpp";
   FS.file.fmon_h.fpath = FS.file.libdir + "/" + FS.file.fmon_h.fname;
 
   FS.file.fmon_c.dir = outpath;
-  FS.file.fmon_c.fname = FS.gen.drvname + "-fmon.c";
+  FS.file.fmon_c.fname = FS.gen.drvname + "-fmon.cpp";
   FS.file.fmon_c.fpath = FS.file.usrdir + "/" + FS.file.fmon_c.fname;
 
   snprintf(_tmpb, kTmpLen, "%s_USE_BITS_SIGNAL", FS.gen.DRVNAME.c_str());

--- a/src/codegen/fs-creator.h
+++ b/src/codegen/fs-creator.h
@@ -68,13 +68,12 @@ typedef struct
 class FsCreator {
  public:
   FsCreator();
-
+  std::string FindPath(const std::string& outpath);
   void Configure(const std::string& drvname, const std::string& outpath, const std::string& info, uint32_t h, uint32_t l);
-  bool PrepareDirectory(bool rw);
+  bool PrepareDirectory();
 
   std::string CreateSubDir(std::string basepath, std::string subdir, bool rm = true);
 
   AppSettings_t FS;
 
 };
-

--- a/src/codegen/mon-generator.cpp
+++ b/src/codegen/mon-generator.cpp
@@ -24,7 +24,7 @@ uint32_t MonGenerator::FillHeader(FileWriter& wr, std::vector<CiExpr_t*>& sigs,
   // with FMon_* signatures to call from unpack function
   wr.Append("#ifdef %s", aset.gen.usemon_def.c_str());
   wr.Append();
-  wr.Append("#include \"canmonitorutil.hpp\"");
+  wr.Append("#include <nv1_can_gen/src/canmonitorutil.hpp>");
   wr.Append("/*\n\
 This file contains the prototypes of all the functions that will be called\n\
 from each Unpack_*name* function to detect DBC related errors\n\

--- a/src/codegen/mon-generator.cpp
+++ b/src/codegen/mon-generator.cpp
@@ -12,27 +12,24 @@ uint32_t MonGenerator::FillHeader(FileWriter& wr, std::vector<CiExpr_t*>& sigs,
   wr.Append("#pragma once");
   wr.Append();
 
-  wr.Append("#ifdef __cplusplus\nextern \"C\" {\n#endif");
-  wr.Append();
-
   wr.Append("// DBC file version");
   wr.Append("#define %s_FMON (%uU)", aset.gen.verhigh_def.c_str(), aset.gen.hiver);
   wr.Append("#define %s_FMON (%uU)", aset.gen.verlow_def.c_str(), aset.gen.lowver);
   wr.Append();
 
-  wr.Append("#include \"%s-config.h\"", aset.gen.drvname.c_str());
+  wr.Append("#include \"%s-config.hpp\"", aset.gen.drvname.c_str());
   wr.Append();
 
   // put diagmonitor ifdef selection for including @drv-fmon header
   // with FMon_* signatures to call from unpack function
   wr.Append("#ifdef %s", aset.gen.usemon_def.c_str());
   wr.Append();
-  wr.Append("#include \"canmonitorutil.h\"");
+  wr.Append("#include \"canmonitorutil.hpp\"");
   wr.Append("/*\n\
 This file contains the prototypes of all the functions that will be called\n\
 from each Unpack_*name* function to detect DBC related errors\n\
 It is the user responsibility to defined these functions in the\n\
-separated .c file. If it won't be done the linkage error will happen\n*/");
+separated .cpp file. If it won't be done the linkage error will happen\n*/");
   wr.Append();
 
   wr.Append("#ifdef %s_USE_MONO_FMON", aset.gen.DRVNAME.c_str());
@@ -77,8 +74,6 @@ separated .c file. If it won't be done the linkage error will happen\n*/");
 
   wr.Append("#endif // %s", aset.gen.usemon_def.c_str());
   wr.Append();
-
-  wr.Append("#ifdef __cplusplus\n}\n#endif");
 
   return 0;
 }

--- a/src/helpers/formatter.cpp
+++ b/src/helpers/formatter.cpp
@@ -164,6 +164,7 @@ std::string prt_double(double value, size_t precision, bool usedot)
     {
       s += ".0";
     }
+    s += "f";
 
     return s;
   }
@@ -197,6 +198,7 @@ std::string prt_double(double value, size_t precision, bool usedot)
     // xxx.x(x)
     s.resize(dotpos + addtail + 1);
   }
+  s += "f";
 
   return s;
 }

--- a/src/parser/dbcscanner.cpp
+++ b/src/parser/dbcscanner.cpp
@@ -79,12 +79,6 @@ void DbcScanner::ParseMessageInfo(istream& readstrm)
     // New message line has been found
     if (lparser.IsMessageLine(sline))
     {
-      // if actual message, check DLC value for being max
-      if ((pMsg != nullptr) && (pMsg->DLC > dblist.maxDlcValue))
-      {
-        dblist.maxDlcValue = pMsg->DLC;
-      }
-
       // the message will be added only if pMsg is not nullptr
       AddMessage(pMsg);
 
@@ -98,6 +92,12 @@ void DbcScanner::ParseMessageInfo(istream& readstrm)
         // the message has invalid format so drop it and wait next one
         delete pMsg;
         pMsg = nullptr;
+      }
+
+      // if actual message, check DLC value for being max
+      if ((pMsg != nullptr) && (pMsg->DLC > dblist.maxDlcValue))
+      {
+        dblist.maxDlcValue = pMsg->DLC;
       }
     }
 

--- a/src/parser/dbcscanner.cpp
+++ b/src/parser/dbcscanner.cpp
@@ -1,5 +1,6 @@
 #include "dbcscanner.h"
 #include <cstring>
+#include <sstream>
 #include <algorithm>
 #include <math.h>
 #include "../helpers/formatter.h"
@@ -341,23 +342,15 @@ void DbcScanner::SetDefualtMessage(MessageDescriptor_t* message)
 void DbcScanner::FindVersion(const std::string& instr)
 {
   // try to find version string which looks like: VERSION "x.x"
-  static constexpr char* versionAttr = (char*)"VERSION";
-  static constexpr size_t VER_MIN_LENGTH = strlen(versionAttr);
-
+  std::istringstream iss(instr);
+  std::string marker;
+  char token;
   uint32_t h = 0, l = 0;
-  char marker[VER_MIN_LENGTH + 1u];
 
-  if (instr.size() < VER_MIN_LENGTH)
-  {
-    return;
-  }
-
-  auto ret = std::sscanf(instr.c_str(), "%8s \"%u.%u\"", marker, &h, &l);
-
-  if ((ret == 3) && (std::strcmp(marker, versionAttr) == 0))
-  {
-    // versions have been found, save numeric values
-    dblist.ver.hi = h;
-    dblist.ver.low = l;
+  if (iss >> marker >> token && token == '"' && marker == "VERSION") {
+    if (iss >> h >> token && token == '.' && iss >> l) {
+      dblist.ver.hi = h;
+      dblist.ver.low = l;
+    }
   }
 }

--- a/test/gencode/conf/testdb-config.h
+++ b/test/gencode/conf/testdb-config.h
@@ -51,7 +51,7 @@
 
 
 /* ------------------------------------------------------------------------- *
-  Note(!) that the "canmonitorutil.h" must be accessed in include path:
+  Note(!) that the "canmonitorutil.hpp" must be accessed in include path:
 
   This macro adds:
 
@@ -59,7 +59,7 @@
 
   - capture system tick in unpack function and save value to mon1 field
   to provide to user better missing frame detection code. For this case
-  user must provide function declared in canmonitorutil.h - GetSysTick()
+  user must provide function declared in canmonitorutil.hpp - GetSysTick()
   which may return 1ms uptime.
 
   - calling function FMon_***  (from 'fmon' driver) inside unpack function
@@ -91,8 +91,8 @@
   - "Checksum": constant marker word
 
   - "XOR8": type of method, this text will be passed to GetFrameHash
-  (canmonitorutil.h) function as is, the best use case is to define 'enum
-  DbcCanCrcMethods' in canmonitorutil.h file with all possible
+  (canmonitorutil.hpp) function as is, the best use case is to define 'enum
+  DbcCanCrcMethods' in canmonitorutil.hpp file with all possible
   checksum algorithms (e.g. XOR8, XOR4 etc)
 
   - "3": optional value that will be passed to GetFrameHash as integer value
@@ -109,18 +109,18 @@
 
 
 /* ------------------------------------------------------------------------- *
-  FMon handling model can be build in two ways: 
+  FMon handling model can be build in two ways:
 
-  1 - Default. In this case when specific frame unpack is called the 
+  1 - Default. In this case when specific frame unpack is called the
   specific FMon_{Frame name}_{driver name} functoin will be called.
   User's code scope has to define each of these functions. Each function is
   responsible for the error handling of one frame
 
-  2 - MONO. In this case there is only one function to perform any frame 
+  2 - MONO. In this case there is only one function to perform any frame
   monitoring. This function has to be implemented in the user's code scope.
   This function is named as FMon_MONO_{driver name}. It takes frame id
   which can be used for selection of the logic for a frame monitoring.
-  This mode costs a bit more in runtime but when you often edit you DBC and you 
+  This mode costs a bit more in runtime but when you often edit you DBC and you
   have more than one project it could be more maintanable (there is
   no necessity to replace source code)
 


### PR DESCRIPTION
Fixed memory corruption that was causing an abort when running this on MacOS.  In FindVersion, marker was only 8 bytes.  It needed to be 9 bytes because some strings were 8 characters long.  That would make 9 bytes with the null terminator.
Also, fixed the no -rw option. Before, it would create 000, 001, ... folders, but all of the code folders would be in the output directory instead of the appropriate numbered directory.