### PR TITLE
Fix multiplex sig pack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Set the build type to Debug if not specified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Add debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+
 add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/c-main-generator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/mon-generator.cpp
@@ -22,7 +30,6 @@ add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/maincli.cpp
 )
-
 
 include(FetchContent)
 FetchContent_Declare(
@@ -53,7 +60,6 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(cctest)
-
 
 add_library(
   dummy OBJECT 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,14 +6,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set the build type to Debug if not specified
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug)
-endif()
-
-# Add debug flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-
 add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/c-main-generator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/mon-generator.cpp
@@ -30,6 +22,7 @@ add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/maincli.cpp
 )
+
 
 include(FetchContent)
 FetchContent_Declare(
@@ -60,6 +53,7 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(cctest)
+
 
 add_library(
   dummy OBJECT 

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -891,6 +891,16 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
             fwriter.Append("  }");
           }
         }
+        // Add the final else block for the case where no expected multiplex value matches. Just encode all signals in the byte.
+        if (!first)
+        {
+            fwriter.Append("  else {");
+            if ( !sgs->to_bytes[i].empty() )
+            {
+                fwriter.Append("    %s[%d] |= (uint8_t) ( %s );", arrtxt.c_str(), i, sgs->to_bytes[i].c_str());
+            }
+            fwriter.Append("  }");
+        }
       }
     }
     else 

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -914,7 +914,7 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
       sgs->msg.CsmSig->Name.c_str(), arrtxt.c_str(), sgs->msg.Name.c_str(),
       sgs->msg.Name.c_str(), sgs->msg.CsmMethod.c_str(), sgs->msg.CsmOp);
 
-    fwriter.Append("  %s[%d] |= (uint8_t) (%s);", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
+    fwriter.Append("  %s[%d] |= (uint8_t) ( %s );", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
 
     fwriter.Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
     fwriter.Append();

--- a/src/codegen/c-sigprinter.h
+++ b/src/codegen/c-sigprinter.h
@@ -18,8 +18,11 @@ class CSigPrinter {
  private:
   int32_t BuildCConvertExprs(CiExpr_t* msg);
 
-  std::string PrintSignalExpr(const SignalDescriptor_t* sig, std::vector<std::string>& to_bytes);
+  std::string PrintSignalExpr(const SignalDescriptor_t* sig, const std::vector<int> mux_values, std::vector<std::string>& to_bytes, std::vector<std::vector<std::string>>& to_bytes_mux);
+
+  void AppendToAllMuxValues(std::vector<std::string>& to_bytes_mux, int mux_ind, const std::string& workbuff);
 
   void AppendToByteLine(std::string& expr, std::string str);
 
+  void FindMultiplexorValues(const MessageDescriptor_t& message, std::vector<int>& mux_values);
 };

--- a/src/parser/dbclineparser.cpp
+++ b/src/parser/dbclineparser.cpp
@@ -212,6 +212,9 @@ bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& 
       else
       {
         sig->Multiplex = MultiplexType::kMulValue;
+        // Multiplex value e.g m0, m1, m2...
+        // Convert to integer
+        sig->MultiplexValue = atoi(halfs[2].c_str() + 1);
       }
     }
   }

--- a/src/types/c-expr.h
+++ b/src/types/c-expr.h
@@ -18,4 +18,19 @@ typedef struct
   // frame fields to data bytes
   std::vector<std::string> to_bytes;
 
+  // another field containing expressions for converting
+  // frame fields to data bytes, but includes a different expression
+  // for each potential multiplexor value.
+  // i.e if the master multiplexor signal is 0, the first expression
+  // should be used, if it is 1, the second expression is used, etc.
+  // First dimension is the byte index, second dimension is the multiplexor value.
+  std::vector<std::vector<std::string>> to_bytes_mux;
+  // Store the corresponding multiplexor values for each expression
+  // since multiplexor values are not necessarily contiguous, we need
+  // to store the values explicitly. This vector should have the same
+  // size as the second dim of the to_bytes_mux and each element corresponds to the multiplexor
+  // value for the corresponding expression in to_bytes_mux.
+  // i.e to_bytes_mux[0 to 7].size() == mux_values.size()
+  std::vector<int> mux_values; 
+
 } CiExpr_t;

--- a/src/types/message.h
+++ b/src/types/message.h
@@ -91,6 +91,8 @@ typedef struct
 
   MultiplexType Multiplex;
 
+  uint32_t MultiplexValue;
+
 } SignalDescriptor_t;
 
 typedef struct

--- a/test/testdb2.dbc
+++ b/test/testdb2.dbc
@@ -1,0 +1,109 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: MCU VMU
+
+
+BO_ 1096 MUX_SIG_TEST1: 8 MCU
+ SG_ mux8_sig1 m8 : 8|8@1+ (1,0) [1|3] ""  VMU
+ SG_ mux8_sig2 m8 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
+ SG_ mux7_sig1 m7 : 8|8@1+ (1,0) [1|3] ""  VMU
+ SG_ mux7_sig2 m7 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
+ SG_ mux6_sig1 m6 : 8|48@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig1 m0 : 32|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig2 m0 : 24|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux5_sig1 m5 : 8|48@1+ (1,0) [0|0] ""  VMU
+ SG_ mux4_sig4 m4 : 8|32@1+ (1,0) [0|0] ""  VMU
+ SG_ mux4_sig3 m3 : 24|16@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig3 m0 : 16|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig4 m0 : 8|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux2_sig1 m2 : 8|16@1+ (1,-32767) [0|32760] "RPM"  VMU
+ SG_ mux1_sig1 m1 : 8|15@1+ (0.125,0) [0|4090] "Nm"  VMU
+ SG_ mux3_sig1 m3 : 16|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux3_sig2 m3 : 8|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux_master M : 0|7@1+ (1,0) [0|0] ""  VMU
+ SG_ signal1 : 7|1@1+ (1,0) [0|0] ""  VMU
+
+BO_ 1091 SIG_TEST1: 5 MCU
+ SG_ signal1 : 36|4@1+ (1,0) [0|15] ""  VMU
+ SG_ signal2 : 0|16@1+ (1,0) [0|65535] ""  VMU
+
+BO_ 66 MUX_SIG_TEST2: 5 VMU
+ SG_ mux4_sig1 m4 : 16|16@1+ (1,-32767) [4294934536|32760] "RPM" Vector__XXX
+ SG_ mux4_sig2 m4 : 0|16@1+ (0.125,-4096) [4294963206|4090] "Nm" Vector__XXX
+ SG_ mux1_sig1 m1 : 0|16@1+ (0.125,-4096) [4294963206|4090] "Nm"  MCU
+ SG_ mux3_sig3 m3 : 0|16@1+ (0.125,-4096) [0|4090] "V"  MCU
+ SG_ signal1 : 36|4@1+ (1,0) [0|15] ""  MCU
+ SG_ mux2_sig1 m2 : 16|16@1+ (1,-32767) [4294934536|32760] "RPM"  MCU
+ SG_ mux_master M : 32|3@1+ (1,0) [1|7] ""  MCU
+
+BO_ 65 MUX_SIG_TEST3: 6 VMU
+ SG_ signal1 : 6|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ max_master M : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ mux1_sig1 m1 : 3|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ signal2 : 5|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ signal3 : 24|16@1+ (1,-32767) [4294934536|32760] "RPM" Vector__XXX
+ SG_ mux1_sig2 m1 : 8|16@1+ (0.125,-4096) [4294963206|4090] "Nm" Vector__XXX
+ SG_ mux0_sig1 m0 : 6|1@1+ (1,0) [0|0] ""  MCU
+ SG_ mux0_sig2 m0 : 8|16@1+ (0.125,-4096) [0|4090] "V"  MCU
+ SG_ mux0_sig3 m0 : 3|2@1+ (1,0) [1|3] ""  MCU
+ SG_ signal4 : 44|4@1+ (1,0) [0|15] ""  MCU
+ SG_ mux0_sig4 m0 : 8|16@1+ (0.125,-4096) [4294963206|4090] "Nm"  MCU
+ SG_ signal5 : 0|3@1+ (1,0) [0|3] ""  MCU
+
+BO_ 1093 SIG_TEST2: 3 MCU
+ SG_ mux_master M : 0|7@1+ (1,0) [0|127] ""  VMU
+
+
+
+BA_DEF_ EV_  "Version" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "Version" "1.0";
+BA_DEF_DEF_  "BusType" "";
+BA_ "BusType" "CAN";
+VAL_ 1096 mux8_sig1 1 "Mode1" 2 "Mode2" 3 "Mode3" ;
+VAL_ 1096 mux7_sig1 1 "Mode1" 2 "Mode2" 3 "Mode3" ;
+VAL_ 1096 mux_master 0 "Mode0" 1 "Mode1" 2 "Mode2" 3 "Mode3" 4 "Mode4" 5 "Mode5" 6 "Mode6" 7 "Mode7" 8 "Mode8" ;
+VAL_ 1096 signal1 0 "Mode0" 1 "Mode1" ;
+VAL_ 66 mux_master 1 "Mode1" 2 "Mode2" 3 "Mode3" 4 "Mode4" 5 "Reserved" 6 "Reserved" 7 "Reserved" ;
+VAL_ 65 signal1 0 "mode0" 1 "mode1" ;
+VAL_ 65 max_master 1 "ON" 0 "OFF" ;
+VAL_ 65 mux1_sig1 1 "Mode1" ;
+VAL_ 65 signal2 0 "mode0" 1 "mode1" ;
+VAL_ 65 mux0_sig1 1 "invalid" 0 "valid" ;
+VAL_ 65 mux0_sig3 1 "mode1" 2 "mode2" 3 "mode3" ;
+VAL_ 65 signal5 0 "mode0" 1 "mode1" 3 "mode3" 4 "mode4" ;
+VAL_ 1093 mux_master 0 "mode0" ;
+


### PR DESCRIPTION
I fixed the signal packing for multiplex signals, issue #31

The new generated code takes into account the master multiplex value when generating the Pack functions.
I added an example dbc file test2.dbc that highlights the problem. 
One of the messages in this dbc file is:
```
BO_ 1096 MUX_SIG_TEST1: 8 MCU
 SG_ mux8_sig1 m8 : 8|8@1+ (1,0) [1|3] ""  VMU
 SG_ mux8_sig2 m8 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
 SG_ mux7_sig1 m7 : 8|8@1+ (1,0) [1|3] ""  VMU
 SG_ mux7_sig2 m7 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
 SG_ mux6_sig1 m6 : 8|48@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig1 m0 : 32|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig2 m0 : 24|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux5_sig1 m5 : 8|48@1+ (1,0) [0|0] ""  VMU
 SG_ mux4_sig4 m4 : 8|32@1+ (1,0) [0|0] ""  VMU
 SG_ mux4_sig3 m3 : 24|16@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig3 m0 : 16|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig4 m0 : 8|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux2_sig1 m2 : 8|16@1+ (1,-32767) [0|32760] "RPM"  VMU
 SG_ mux1_sig1 m1 : 8|15@1+ (0.125,0) [0|4090] "Nm"  VMU
 SG_ mux3_sig1 m3 : 16|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux3_sig2 m3 : 8|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux_master M : 0|7@1+ (1,0) [0|0] ""  VMU
 SG_ signal1 : 7|1@1+ (1,0) [0|0] ""  VMU
```

Here is a comparison of the generated code before this fix for the Pack function of the **MUX_SIG_TEST1** CAN message from the test2.dbc file.
```
uint32_t Pack_MUX_SIG_TEST1_testdb(MUX_SIG_TEST1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
{
  uint8_t i; for (i = 0u; i < TESTDB_VALIDATE_DLC(MUX_SIG_TEST1_DLC); _d[i++] = TESTDB_INITIAL_BYTE_VALUE);

#ifdef TESTDB_USE_SIGFLOAT
  _m->mux1_sig1_ro = (uint16_t) TESTDB_mux1_sig1_ro_toS(_m->mux1_sig1_phys);
  _m->mux2_sig1_ro = (uint16_t) TESTDB_mux2_sig1_ro_toS(_m->mux2_sig1_phys);
  _m->mux8_sig2_ro = (uint16_t) TESTDB_mux8_sig2_ro_toS(_m->mux8_sig2_phys);
  _m->mux7_sig2_ro = (uint16_t) TESTDB_mux7_sig2_ro_toS(_m->mux7_sig2_phys);
#endif // TESTDB_USE_SIGFLOAT

  _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  _d[1] |= (uint8_t) ( (_m->mux8_sig1 & (0xFFU)) | (_m->mux7_sig1 & (0xFFU)) | (_m->mux6_sig1 & (0xFFU)) | (_m->mux3_sig2 & (0xFFU)) | (_m->mux5_sig1 & (0xFFU)) | (_m->mux4_sig4 & (0xFFU)) | (_m->mux1_sig1_ro & (0xFFU)) | (_m->mux0_sig4 & (0xFFU)) | (_m->mux2_sig1_ro & (0xFFU)) );
  _d[2] |= (uint8_t) ( ((_m->mux6_sig1 >> 8U) & (0xFFU)) | ((_m->mux5_sig1 >> 8U) & (0xFFU)) | ((_m->mux4_sig4 >> 8U) & (0xFFU)) | ((_m->mux1_sig1_ro >> 8U) & (0x7FU)) | ((_m->mux2_sig1_ro >> 8U) & (0xFFU)) | (_m->mux8_sig2_ro & (0xFFU)) | (_m->mux3_sig1 & (0xFFU)) | (_m->mux0_sig3 & (0xFFU)) | (_m->mux7_sig2_ro & (0xFFU)) );
  _d[3] |= (uint8_t) ( ((_m->mux6_sig1 >> 16U) & (0xFFU)) | ((_m->mux5_sig1 >> 16U) & (0xFFU)) | ((_m->mux4_sig4 >> 16U) & (0xFFU)) | ((_m->mux8_sig2_ro >> 8U) & (0x7FU)) | ((_m->mux7_sig2_ro >> 8U) & (0x7FU)) | (_m->mux4_sig3 & (0xFFU)) | (_m->mux0_sig2 & (0xFFU)) );
  _d[4] |= (uint8_t) ( ((_m->mux6_sig1 >> 24U) & (0xFFU)) | ((_m->mux5_sig1 >> 24U) & (0xFFU)) | ((_m->mux4_sig4 >> 24U) & (0xFFU)) | ((_m->mux4_sig3 >> 8U) & (0xFFU)) | (_m->mux0_sig1 & (0xFFU)) );
  _d[5] |= (uint8_t) ( ((_m->mux6_sig1 >> 32U) & (0xFFU)) | ((_m->mux5_sig1 >> 32U) & (0xFFU)) );
  _d[6] |= (uint8_t) ( ((_m->mux6_sig1 >> 40U) & (0xFFU)) | ((_m->mux5_sig1 >> 40U) & (0xFFU)) );

  *_len = (uint8_t) MUX_SIG_TEST1_DLC;
  *_ide = (uint8_t) MUX_SIG_TEST1_IDE;
  return MUX_SIG_TEST1_CANID;
}
```

And now below is the generated code after this fix.
CAN messages with no multiplex values will generate the original style Pack functions this change only affects messages that contain multiplex signals. 
**Note1:** For **_d[0]** the signals **mux_master** and **signal1** are not affected by the value of mux_master so they appear in each possible multiplex master if statement. The other bytes d[1] to d[6] contain only the mux signals that are associated with each mux_master value. 

**Note2:** For the case where the mux_master has a value that doesn't equal any of the expected multiplex signal values (e.g the last else statement for each byte) just pack all the multiplex signals for each byte as none of them are valid anyway. We could have tried only packing the master multiplexor and non multiplexed signals for this case but I don't think this would matter since all multiplex signal values would not be valid anyway for this case. 
```
uint32_t Pack_MUX_SIG_TEST1_testdb(MUX_SIG_TEST1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
{
  uint8_t i; for (i = 0u; i < TESTDB_VALIDATE_DLC(MUX_SIG_TEST1_DLC); _d[i++] = TESTDB_INITIAL_BYTE_VALUE);

#ifdef TESTDB_USE_SIGFLOAT
  _m->mux1_sig1_ro = (uint16_t) TESTDB_mux1_sig1_ro_toS(_m->mux1_sig1_phys);
  _m->mux2_sig1_ro = (uint16_t) TESTDB_mux2_sig1_ro_toS(_m->mux2_sig1_phys);
  _m->mux8_sig2_ro = (uint16_t) TESTDB_mux8_sig2_ro_toS(_m->mux8_sig2_phys);
  _m->mux7_sig2_ro = (uint16_t) TESTDB_mux7_sig2_ro_toS(_m->mux7_sig2_phys);
#endif // TESTDB_USE_SIGFLOAT

  if (_m->mux_master == 8) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 7) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 6) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 3) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 5) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 4) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 1) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 0) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else if (_m->mux_master == 2) {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  else {
    _d[0] |= (uint8_t) ( (_m->mux_master & (0x7FU)) | ((_m->signal1 & (0x01U)) << 7U) );
  }
  if (_m->mux_master == 8) {
    _d[1] |= (uint8_t) ( (_m->mux8_sig1 & (0xFFU)) );
  }
  else if (_m->mux_master == 7) {
    _d[1] |= (uint8_t) ( (_m->mux7_sig1 & (0xFFU)) );
  }
  else if (_m->mux_master == 6) {
    _d[1] |= (uint8_t) ( (_m->mux6_sig1 & (0xFFU)) );
  }
  else if (_m->mux_master == 3) {
    _d[1] |= (uint8_t) ( (_m->mux3_sig2 & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[1] |= (uint8_t) ( (_m->mux5_sig1 & (0xFFU)) );
  }
  else if (_m->mux_master == 4) {
    _d[1] |= (uint8_t) ( (_m->mux4_sig4 & (0xFFU)) );
  }
  else if (_m->mux_master == 1) {
    _d[1] |= (uint8_t) ( (_m->mux1_sig1_ro & (0xFFU)) );
  }
  else if (_m->mux_master == 0) {
    _d[1] |= (uint8_t) ( (_m->mux0_sig4 & (0xFFU)) );
  }
  else if (_m->mux_master == 2) {
    _d[1] |= (uint8_t) ( (_m->mux2_sig1_ro & (0xFFU)) );
  }
  else {
    _d[1] |= (uint8_t) ( (_m->mux8_sig1 & (0xFFU)) | (_m->mux7_sig1 & (0xFFU)) | (_m->mux6_sig1 & (0xFFU)) | (_m->mux3_sig2 & (0xFFU)) | (_m->mux5_sig1 & (0xFFU)) | (_m->mux4_sig4 & (0xFFU)) | (_m->mux1_sig1_ro & (0xFFU)) | (_m->mux0_sig4 & (0xFFU)) | (_m->mux2_sig1_ro & (0xFFU)) );
  }
  if (_m->mux_master == 8) {
    _d[2] |= (uint8_t) ( (_m->mux8_sig2_ro & (0xFFU)) );
  }
  else if (_m->mux_master == 7) {
    _d[2] |= (uint8_t) ( (_m->mux7_sig2_ro & (0xFFU)) );
  }
  else if (_m->mux_master == 6) {
    _d[2] |= (uint8_t) ( ((_m->mux6_sig1 >> 8U) & (0xFFU)) );
  }
  else if (_m->mux_master == 3) {
    _d[2] |= (uint8_t) ( (_m->mux3_sig1 & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[2] |= (uint8_t) ( ((_m->mux5_sig1 >> 8U) & (0xFFU)) );
  }
  else if (_m->mux_master == 4) {
    _d[2] |= (uint8_t) ( ((_m->mux4_sig4 >> 8U) & (0xFFU)) );
  }
  else if (_m->mux_master == 1) {
    _d[2] |= (uint8_t) ( ((_m->mux1_sig1_ro >> 8U) & (0x7FU)) );
  }
  else if (_m->mux_master == 0) {
    _d[2] |= (uint8_t) ( (_m->mux0_sig3 & (0xFFU)) );
  }
  else if (_m->mux_master == 2) {
    _d[2] |= (uint8_t) ( ((_m->mux2_sig1_ro >> 8U) & (0xFFU)) );
  }
  else {
    _d[2] |= (uint8_t) ( ((_m->mux6_sig1 >> 8U) & (0xFFU)) | ((_m->mux5_sig1 >> 8U) & (0xFFU)) | ((_m->mux4_sig4 >> 8U) & (0xFFU)) | ((_m->mux1_sig1_ro >> 8U) & (0x7FU)) | ((_m->mux2_sig1_ro >> 8U) & (0xFFU)) | (_m->mux8_sig2_ro & (0xFFU)) | (_m->mux3_sig1 & (0xFFU)) | (_m->mux0_sig3 & (0xFFU)) | (_m->mux7_sig2_ro & (0xFFU)) );
  }
  if (_m->mux_master == 8) {
    _d[3] |= (uint8_t) ( ((_m->mux8_sig2_ro >> 8U) & (0x7FU)) );
  }
  else if (_m->mux_master == 7) {
    _d[3] |= (uint8_t) ( ((_m->mux7_sig2_ro >> 8U) & (0x7FU)) );
  }
  else if (_m->mux_master == 6) {
    _d[3] |= (uint8_t) ( ((_m->mux6_sig1 >> 16U) & (0xFFU)) );
  }
  else if (_m->mux_master == 3) {
    _d[3] |= (uint8_t) ( (_m->mux4_sig3 & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[3] |= (uint8_t) ( ((_m->mux5_sig1 >> 16U) & (0xFFU)) );
  }
  else if (_m->mux_master == 4) {
    _d[3] |= (uint8_t) ( ((_m->mux4_sig4 >> 16U) & (0xFFU)) );
  }
  else if (_m->mux_master == 0) {
    _d[3] |= (uint8_t) ( (_m->mux0_sig2 & (0xFFU)) );
  }
  else {
    _d[3] |= (uint8_t) ( ((_m->mux6_sig1 >> 16U) & (0xFFU)) | ((_m->mux5_sig1 >> 16U) & (0xFFU)) | ((_m->mux4_sig4 >> 16U) & (0xFFU)) | ((_m->mux8_sig2_ro >> 8U) & (0x7FU)) | ((_m->mux7_sig2_ro >> 8U) & (0x7FU)) | (_m->mux4_sig3 & (0xFFU)) | (_m->mux0_sig2 & (0xFFU)) );
  }
  if (_m->mux_master == 6) {
    _d[4] |= (uint8_t) ( ((_m->mux6_sig1 >> 24U) & (0xFFU)) );
  }
  else if (_m->mux_master == 3) {
    _d[4] |= (uint8_t) ( ((_m->mux4_sig3 >> 8U) & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[4] |= (uint8_t) ( ((_m->mux5_sig1 >> 24U) & (0xFFU)) );
  }
  else if (_m->mux_master == 4) {
    _d[4] |= (uint8_t) ( ((_m->mux4_sig4 >> 24U) & (0xFFU)) );
  }
  else if (_m->mux_master == 0) {
    _d[4] |= (uint8_t) ( (_m->mux0_sig1 & (0xFFU)) );
  }
  else {
    _d[4] |= (uint8_t) ( ((_m->mux6_sig1 >> 24U) & (0xFFU)) | ((_m->mux5_sig1 >> 24U) & (0xFFU)) | ((_m->mux4_sig4 >> 24U) & (0xFFU)) | ((_m->mux4_sig3 >> 8U) & (0xFFU)) | (_m->mux0_sig1 & (0xFFU)) );
  }
  if (_m->mux_master == 6) {
    _d[5] |= (uint8_t) ( ((_m->mux6_sig1 >> 32U) & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[5] |= (uint8_t) ( ((_m->mux5_sig1 >> 32U) & (0xFFU)) );
  }
  else {
    _d[5] |= (uint8_t) ( ((_m->mux6_sig1 >> 32U) & (0xFFU)) | ((_m->mux5_sig1 >> 32U) & (0xFFU)) );
  }
  if (_m->mux_master == 6) {
    _d[6] |= (uint8_t) ( ((_m->mux6_sig1 >> 40U) & (0xFFU)) );
  }
  else if (_m->mux_master == 5) {
    _d[6] |= (uint8_t) ( ((_m->mux5_sig1 >> 40U) & (0xFFU)) );
  }
  else {
    _d[6] |= (uint8_t) ( ((_m->mux6_sig1 >> 40U) & (0xFFU)) | ((_m->mux5_sig1 >> 40U) & (0xFFU)) );
  }

  *_len = (uint8_t) MUX_SIG_TEST1_DLC;
  *_ide = (uint8_t) MUX_SIG_TEST1_IDE;
  return MUX_SIG_TEST1_CANID;
}
```





