### PR TITLE
Fix multiplex sig unpack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Set the build type to Debug if not specified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Add debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+
 add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/c-main-generator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/mon-generator.cpp
@@ -22,7 +30,6 @@ add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/maincli.cpp
 )
-
 
 include(FetchContent)
 FetchContent_Declare(
@@ -53,7 +60,6 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(cctest)
-
 
 add_library(
   dummy OBJECT 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,14 +6,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set the build type to Debug if not specified
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug)
-endif()
-
-# Add debug flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-
 add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/c-main-generator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/mon-generator.cpp
@@ -30,6 +22,7 @@ add_executable(coderdbc
     ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/maincli.cpp
 )
+
 
 include(FetchContent)
 FetchContent_Declare(
@@ -60,6 +53,7 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(cctest)
+
 
 add_library(
   dummy OBJECT 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -145,7 +145,7 @@ void CoderApp::GenerateCode()
 
   if (ret)
   {
-    cigen.Generate(scanner.dblist, fscreator.FS);
+    cigen.Generate(scanner.dblist, fscreator.FS, Params.is_multiplex_enabled);
   }
   else
   {
@@ -283,8 +283,8 @@ void CoderApp::PrintHelp()
   std::cout << "   -nofmon:\t no ***-fmon.c generation" << std::endl;
   std::cout << std::endl;
   std::cout << "   -driverdir\t the output path (-out) will be appended by driver name" << std::endl;
-  std::cout << "   -gendate\t the generation date will be included in the header comment section of the source file." <<
-    std::endl;
+  std::cout << "   -gendate\t the generation date will be included in the header comment section of the source file." << std::endl;
+  std::cout << "   -multiplex or -muxgen\t enable multiplex signal packing/unpacking code generation based on multiplexor master signal values for multiplexed signals." << std::endl;
   std::cout << std::endl;
 
   std::cout << "examples:" << std::endl;
@@ -295,10 +295,7 @@ void CoderApp::PrintHelp()
     << std::endl;
   std::cout << "./dbccoder -dbc /home/user/docs/driveshaft.dbc -out /home/user/docs/gen/ -drvname drivedb -nodeutils -rw"
     << std::endl;
-
-  std::cout <<
-    "./dbccoder -dbc /home/user/docs/driveshaft.dbc -out /home/user/docs/gen/ -drvname drivedb -nodeutils" << std::endl;
-
+  std::cout << "./dbccoder -dbc /home/user/docs/driveshaft.dbc -out /home/user/docs/gen/ -drvname drivedb -nodeutils" << std::endl;
   std::cout << "./dbccoder -dbc /home/user/docs/driveshaft.dbc -out /home/user/docs/gen/ -drvname drivedb" << std::endl;
   std::cout << std::endl;
 }

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -683,11 +683,13 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
 {
   // Find the master multiplex signal (if any)
   const SignalDescriptor_t* masterSignal = nullptr;
-  for (const auto& sig : sgs->msg.Signals)
+  size_t masterSignalIndex = 0;
+  for (size_t i = 0; i < sgs->msg.Signals.size(); ++i)
   {
-    if (sig.Multiplex == MultiplexType::kMaster)
+    if (sgs->msg.Signals[i].Multiplex == MultiplexType::kMaster)
     {
-      masterSignal = &sig;
+      masterSignal = &sgs->msg.Signals[i];
+      masterSignalIndex = i;
       break;
     }
   }
@@ -696,7 +698,7 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
   if (masterSignal)
   {
     const char* masterSname = masterSignal->Name.c_str();
-    auto masterExpr = sgs->to_signals[masterSignal->StartBit / 8]; // Assume the start bit gives the correct index for expression
+    auto masterExpr = sgs->to_signals[masterSignalIndex];
     fwriter.Append("  _m->%s = (%s) ( %s );", masterSname, 
       PrintType((int)masterSignal->TypeRo).c_str(), masterExpr.c_str());
   }

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -891,6 +891,16 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
             fwriter.Append("  }");
           }
         }
+        // Add the final else block for the case where no expected multiplex value matches. Just encode all signals in the byte.
+        if (!first)
+        {
+            fwriter.Append("  else {");
+            if ( !sgs->to_bytes[i].empty() )
+            {
+                fwriter.Append("    %s[%d] |= (uint8_t) ( %s );", arrtxt.c_str(), i, sgs->to_bytes[i].c_str());
+            }
+            fwriter.Append("  }");
+        }
       }
     }
     else 

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -753,6 +753,7 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
       }
 
       fwriter.Append("#endif // %s", fdesc->gen.usesigfloat_def.c_str());
+      fwriter.Append("");
     }
 
     // Close the if statement if the signal was multiplexed

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -697,7 +697,8 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
     fwriter.Append("  _m->%s = (%s) ( %s );", masterSname, 
       PrintType((int)masterSignal->TypeRo).c_str(), masterExpr.c_str());
   }
-
+  
+  // Unpack the rest of the signals
   for (size_t num = 0; num < sgs->to_signals.size(); num++)
   {
     const auto& signal = sgs->msg.Signals[num];
@@ -765,7 +766,10 @@ void CiMainGenerator::WriteUnpackBody(const CiExpr_t* sgs)
     // Add a newline after processing the last signal
     if (num + 1 == sgs->to_signals.size())
     {
-      fwriter.Append("");
+      // No newline if the last signal was a multiplexed signal, as it already has a newline
+      if (signal.IsSimpleSig) {
+        fwriter.Append("");
+      }
     }
   }
 

--- a/src/codegen/c-main-generator.cpp
+++ b/src/codegen/c-main-generator.cpp
@@ -914,7 +914,7 @@ void CiMainGenerator::PrintPackCommonText(const std::string& arrtxt, const CiExp
       sgs->msg.CsmSig->Name.c_str(), arrtxt.c_str(), sgs->msg.Name.c_str(),
       sgs->msg.Name.c_str(), sgs->msg.CsmMethod.c_str(), sgs->msg.CsmOp);
 
-    fwriter.Append("  %s[%d] |= (uint8_t) (%s);", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
+    fwriter.Append("  %s[%d] |= (uint8_t) ( %s );", arrtxt.c_str(), sgs->msg.CsmByteNum, sgs->msg.CsmToByteExpr.c_str());
 
     fwriter.Append("#endif // %s", fdesc->gen.usecsm_def.c_str());
     fwriter.Append();

--- a/src/codegen/c-main-generator.h
+++ b/src/codegen/c-main-generator.h
@@ -10,7 +10,7 @@
 
 class CiMainGenerator {
  public:
-  void Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd);
+  void Generate(DbcMessageList_t& dlist, const AppSettings_t& fsd, bool mux_enabled);
 
  private:
 
@@ -39,4 +39,6 @@ class CiMainGenerator {
   // Macro for frame DLC validation
   std::string prt_dlcValidateMacroName;
   const AppSettings_t* fdesc;
+  // Bool to turn on or off code generation based on multiplexor master signal values is enabled for multiplexed signals.
+  bool is_multiplex_enabled;
 };

--- a/src/codegen/c-sigprinter.h
+++ b/src/codegen/c-sigprinter.h
@@ -18,8 +18,11 @@ class CSigPrinter {
  private:
   int32_t BuildCConvertExprs(CiExpr_t* msg);
 
-  std::string PrintSignalExpr(const SignalDescriptor_t* sig, std::vector<std::string>& to_bytes);
+  std::string PrintSignalExpr(const SignalDescriptor_t* sig, const std::vector<int> mux_values, std::vector<std::string>& to_bytes, std::vector<std::vector<std::string>>& to_bytes_mux);
+
+  void AppendToAllMuxValues(std::vector<std::string>& to_bytes_mux, int mux_ind, const std::string& workbuff);
 
   void AppendToByteLine(std::string& expr, std::string str);
 
+  void FindMultiplexorValues(const MessageDescriptor_t& message, std::vector<int>& mux_values);
 };

--- a/src/options-parser.cpp
+++ b/src/options-parser.cpp
@@ -86,6 +86,10 @@ OptionsParser::GenOptions OptionsParser::GetOptions(int argc, char** argv)
     {
       retpairs.add_gen_date = true;
     }
+    else if (temppairs[i].first.compare("-multiplex") == 0 || temppairs[i].first.compare("-muxgen") == 0)
+    {
+      retpairs.is_multiplex_enabled = true;
+    }
   }
 
   return retpairs;

--- a/src/options-parser.h
+++ b/src/options-parser.h
@@ -48,6 +48,9 @@ class OptionsParser {
 
     /// @brief help is requested
     bool is_help{false};
+
+    /// @brief Code generation based on multiplexor master signal values is enabled for multiplexed signals. 
+    bool is_multiplex_enabled{false};
   };
 
   /// @brief Parses arguments and theirs optional values

--- a/src/parser/dbclineparser.cpp
+++ b/src/parser/dbclineparser.cpp
@@ -212,6 +212,9 @@ bool DbcLineParser::ParseSignalLine(SignalDescriptor_t* sig, const std::string& 
       else
       {
         sig->Multiplex = MultiplexType::kMulValue;
+        // Multiplex value e.g m0, m1, m2...
+        // Convert to integer
+        sig->MultiplexValue = atoi(halfs[2].c_str() + 1);
       }
     }
   }

--- a/src/types/c-expr.h
+++ b/src/types/c-expr.h
@@ -18,4 +18,19 @@ typedef struct
   // frame fields to data bytes
   std::vector<std::string> to_bytes;
 
+  // another field containing expressions for converting
+  // frame fields to data bytes, but includes a different expression
+  // for each potential multiplexor value.
+  // i.e if the master multiplexor signal is 0, the first expression
+  // should be used, if it is 1, the second expression is used, etc.
+  // First dimension is the byte index, second dimension is the multiplexor value.
+  std::vector<std::vector<std::string>> to_bytes_mux;
+  // Store the corresponding multiplexor values for each expression
+  // since multiplexor values are not necessarily contiguous, we need
+  // to store the values explicitly. This vector should have the same
+  // size as the second dim of the to_bytes_mux and each element corresponds to the multiplexor
+  // value for the corresponding expression in to_bytes_mux.
+  // i.e to_bytes_mux[0 to 7].size() == mux_values.size()
+  std::vector<int> mux_values; 
+
 } CiExpr_t;

--- a/src/types/message.h
+++ b/src/types/message.h
@@ -91,6 +91,8 @@ typedef struct
 
   MultiplexType Multiplex;
 
+  uint32_t MultiplexValue;
+
 } SignalDescriptor_t;
 
 typedef struct

--- a/test/testdb2.dbc
+++ b/test/testdb2.dbc
@@ -1,0 +1,109 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: MCU VMU
+
+
+BO_ 1096 MUX_SIG_TEST1: 8 MCU
+ SG_ mux8_sig1 m8 : 8|8@1+ (1,0) [1|3] ""  VMU
+ SG_ mux8_sig2 m8 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
+ SG_ mux7_sig1 m7 : 8|8@1+ (1,0) [1|3] ""  VMU
+ SG_ mux7_sig2 m7 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
+ SG_ mux6_sig1 m6 : 8|48@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig1 m0 : 32|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig2 m0 : 24|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux5_sig1 m5 : 8|48@1+ (1,0) [0|0] ""  VMU
+ SG_ mux4_sig4 m4 : 8|32@1+ (1,0) [0|0] ""  VMU
+ SG_ mux4_sig3 m3 : 24|16@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig3 m0 : 16|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux0_sig4 m0 : 8|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux2_sig1 m2 : 8|16@1+ (1,-32767) [0|32760] "RPM"  VMU
+ SG_ mux1_sig1 m1 : 8|15@1+ (0.125,0) [0|4090] "Nm"  VMU
+ SG_ mux3_sig1 m3 : 16|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux3_sig2 m3 : 8|8@1+ (1,0) [0|0] ""  VMU
+ SG_ mux_master M : 0|7@1+ (1,0) [0|0] ""  VMU
+ SG_ signal1 : 7|1@1+ (1,0) [0|0] ""  VMU
+
+BO_ 1091 SIG_TEST1: 5 MCU
+ SG_ signal1 : 36|4@1+ (1,0) [0|15] ""  VMU
+ SG_ signal2 : 0|16@1+ (1,0) [0|65535] ""  VMU
+
+BO_ 66 MUX_SIG_TEST2: 5 VMU
+ SG_ mux4_sig1 m4 : 16|16@1+ (1,-32767) [4294934536|32760] "RPM" Vector__XXX
+ SG_ mux4_sig2 m4 : 0|16@1+ (0.125,-4096) [4294963206|4090] "Nm" Vector__XXX
+ SG_ mux1_sig1 m1 : 0|16@1+ (0.125,-4096) [4294963206|4090] "Nm"  MCU
+ SG_ mux3_sig3 m3 : 0|16@1+ (0.125,-4096) [0|4090] "V"  MCU
+ SG_ signal1 : 36|4@1+ (1,0) [0|15] ""  MCU
+ SG_ mux2_sig1 m2 : 16|16@1+ (1,-32767) [4294934536|32760] "RPM"  MCU
+ SG_ mux_master M : 32|3@1+ (1,0) [1|7] ""  MCU
+
+BO_ 65 MUX_SIG_TEST3: 6 VMU
+ SG_ signal1 : 6|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ max_master M : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ mux1_sig1 m1 : 3|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ signal2 : 5|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ signal3 : 24|16@1+ (1,-32767) [4294934536|32760] "RPM" Vector__XXX
+ SG_ mux1_sig2 m1 : 8|16@1+ (0.125,-4096) [4294963206|4090] "Nm" Vector__XXX
+ SG_ mux0_sig1 m0 : 6|1@1+ (1,0) [0|0] ""  MCU
+ SG_ mux0_sig2 m0 : 8|16@1+ (0.125,-4096) [0|4090] "V"  MCU
+ SG_ mux0_sig3 m0 : 3|2@1+ (1,0) [1|3] ""  MCU
+ SG_ signal4 : 44|4@1+ (1,0) [0|15] ""  MCU
+ SG_ mux0_sig4 m0 : 8|16@1+ (0.125,-4096) [4294963206|4090] "Nm"  MCU
+ SG_ signal5 : 0|3@1+ (1,0) [0|3] ""  MCU
+
+BO_ 1093 SIG_TEST2: 3 MCU
+ SG_ mux_master M : 0|7@1+ (1,0) [0|127] ""  VMU
+
+
+
+BA_DEF_ EV_  "Version" STRING ;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "Version" "1.0";
+BA_DEF_DEF_  "BusType" "";
+BA_ "BusType" "CAN";
+VAL_ 1096 mux8_sig1 1 "Mode1" 2 "Mode2" 3 "Mode3" ;
+VAL_ 1096 mux7_sig1 1 "Mode1" 2 "Mode2" 3 "Mode3" ;
+VAL_ 1096 mux_master 0 "Mode0" 1 "Mode1" 2 "Mode2" 3 "Mode3" 4 "Mode4" 5 "Mode5" 6 "Mode6" 7 "Mode7" 8 "Mode8" ;
+VAL_ 1096 signal1 0 "Mode0" 1 "Mode1" ;
+VAL_ 66 mux_master 1 "Mode1" 2 "Mode2" 3 "Mode3" 4 "Mode4" 5 "Reserved" 6 "Reserved" 7 "Reserved" ;
+VAL_ 65 signal1 0 "mode0" 1 "mode1" ;
+VAL_ 65 max_master 1 "ON" 0 "OFF" ;
+VAL_ 65 mux1_sig1 1 "Mode1" ;
+VAL_ 65 signal2 0 "mode0" 1 "mode1" ;
+VAL_ 65 mux0_sig1 1 "invalid" 0 "valid" ;
+VAL_ 65 mux0_sig3 1 "mode1" 2 "mode2" 3 "mode3" ;
+VAL_ 65 signal5 0 "mode0" 1 "mode1" 3 "mode3" 4 "mode4" ;
+VAL_ 1093 mux_master 0 "mode0" ;
+


### PR DESCRIPTION
Fixes issues #33.

The generated code now only unpacks the correct multiplex signals associated with the mutliplex master value.
These changes do not affect CAN messages that have no mutliplex values. They also don't affect the decoding of unmultiplex signals or the multiplex master signal in a CAN message.

A comparison of decoding the following CAN msg below is shown:

```
BO_ 1096 MUX_SIG_TEST1: 8 MCU
 SG_ mux8_sig1 m8 : 8|8@1+ (1,0) [1|3] ""  VMU
 SG_ mux8_sig2 m8 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
 SG_ mux7_sig1 m7 : 8|8@1+ (1,0) [1|3] ""  VMU
 SG_ mux7_sig2 m7 : 16|15@1+ (0.125,0) [0|4090] "V"  VMU
 SG_ mux6_sig1 m6 : 8|48@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig1 m0 : 32|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig2 m0 : 24|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux5_sig1 m5 : 8|48@1+ (1,0) [0|0] ""  VMU
 SG_ mux4_sig4 m4 : 8|32@1+ (1,0) [0|0] ""  VMU
 SG_ mux4_sig3 m3 : 24|16@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig3 m0 : 16|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux0_sig4 m0 : 8|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux2_sig1 m2 : 8|16@1+ (1,-32767) [0|32760] "RPM"  VMU
 SG_ mux1_sig1 m1 : 8|15@1+ (0.125,0) [0|4090] "Nm"  VMU
 SG_ mux3_sig1 m3 : 16|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux3_sig2 m3 : 8|8@1+ (1,0) [0|0] ""  VMU
 SG_ mux_master M : 0|7@1+ (1,0) [0|0] ""  VMU
 SG_ signal1 : 7|1@1+ (1,0) [0|0] ""  VMU
 ```
 
 Before this fix the following was generated.
 ```
 uint32_t Unpack_MUX_SIG_TEST1_testdb(MUX_SIG_TEST1_t* _m, const uint8_t* _d, uint8_t dlc_)
{
  (void)dlc_;
  _m->mux_master = (uint8_t) ( (_d[0] & (0x7FU)) );
  _m->signal1 = (uint8_t) ( ((_d[0] >> 7U) & (0x01U)) );
  _m->mux8_sig1 = (uint8_t) ( (_d[1] & (0xFFU)) );
  _m->mux7_sig1 = (uint8_t) ( (_d[1] & (0xFFU)) );
  _m->mux6_sig1 = (uint64_t) ( ((uint64_t)(_d[6] & (0xFFU)) << 40U) | ((uint64_t)(_d[5] & (0xFFU)) << 32U) | ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  _m->mux3_sig2 = (uint8_t) ( (_d[1] & (0xFFU)) );
  _m->mux5_sig1 = (uint64_t) ( ((uint64_t)(_d[6] & (0xFFU)) << 40U) | ((uint64_t)(_d[5] & (0xFFU)) << 32U) | ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  _m->mux4_sig4 = (uint32_t) ( ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  _m->mux1_sig1_ro = (uint16_t) ( ((_d[2] & (0x7FU)) << 8U) | (_d[1] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
  _m->mux1_sig1_phys = (sigfloat_t)(TESTDB_mux1_sig1_ro_fromS(_m->mux1_sig1_ro));
#endif // TESTDB_USE_SIGFLOAT

  _m->mux0_sig4 = (uint8_t) ( (_d[1] & (0xFFU)) );
  _m->mux2_sig1_ro = (uint16_t) ( ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
  _m->mux2_sig1_phys = (int32_t) TESTDB_mux2_sig1_ro_fromS(_m->mux2_sig1_ro);
#endif // TESTDB_USE_SIGFLOAT

  _m->mux8_sig2_ro = (uint16_t) ( ((_d[3] & (0x7FU)) << 8U) | (_d[2] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
  _m->mux8_sig2_phys = (sigfloat_t)(TESTDB_mux8_sig2_ro_fromS(_m->mux8_sig2_ro));
#endif // TESTDB_USE_SIGFLOAT

  _m->mux3_sig1 = (uint8_t) ( (_d[2] & (0xFFU)) );
  _m->mux0_sig3 = (uint8_t) ( (_d[2] & (0xFFU)) );
  _m->mux7_sig2_ro = (uint16_t) ( ((_d[3] & (0x7FU)) << 8U) | (_d[2] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
  _m->mux7_sig2_phys = (sigfloat_t)(TESTDB_mux7_sig2_ro_fromS(_m->mux7_sig2_ro));
#endif // TESTDB_USE_SIGFLOAT

  _m->mux4_sig3 = (uint16_t) ( ((_d[4] & (0xFFU)) << 8U) | (_d[3] & (0xFFU)) );
  _m->mux0_sig2 = (uint8_t) ( (_d[3] & (0xFFU)) );
  _m->mux0_sig1 = (uint8_t) ( (_d[4] & (0xFFU)) );

#ifdef TESTDB_USE_DIAG_MONITORS
  _m->mon1.dlc_error = (dlc_ < MUX_SIG_TEST1_DLC);
  _m->mon1.last_cycle = GetSystemTick();
  _m->mon1.frame_cnt++;

  FMon_MUX_SIG_TEST1_testdb(&_m->mon1, MUX_SIG_TEST1_CANID);
#endif // TESTDB_USE_DIAG_MONITORS

  return MUX_SIG_TEST1_CANID;
}
```


After this fix it now generates this Unpack function:
```
uint32_t Unpack_MUX_SIG_TEST1_testdb(MUX_SIG_TEST1_t* _m, const uint8_t* _d, uint8_t dlc_)
{
  (void)dlc_;
  _m->mux_master = (uint8_t) ( (_d[0] & (0x7FU)) );
  _m->signal1 = (uint8_t) ( ((_d[0] >> 7U) & (0x01U)) );
  if (_m->mux_master == 8) {
    _m->mux8_sig1 = (uint8_t) ( (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 7) {
    _m->mux7_sig1 = (uint8_t) ( (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 6) {
    _m->mux6_sig1 = (uint64_t) ( ((uint64_t)(_d[6] & (0xFFU)) << 40U) | ((uint64_t)(_d[5] & (0xFFU)) << 32U) | ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 3) {
    _m->mux3_sig2 = (uint8_t) ( (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 5) {
    _m->mux5_sig1 = (uint64_t) ( ((uint64_t)(_d[6] & (0xFFU)) << 40U) | ((uint64_t)(_d[5] & (0xFFU)) << 32U) | ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 4) {
    _m->mux4_sig4 = (uint32_t) ( ((_d[4] & (0xFFU)) << 24U) | ((_d[3] & (0xFFU)) << 16U) | ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 1) {
    _m->mux1_sig1_ro = (uint16_t) ( ((_d[2] & (0x7FU)) << 8U) | (_d[1] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
    _m->mux1_sig1_phys = (sigfloat_t)(TESTDB_mux1_sig1_ro_fromS(_m->mux1_sig1_ro));
#endif // TESTDB_USE_SIGFLOAT

  }
  if (_m->mux_master == 0) {
    _m->mux0_sig4 = (uint8_t) ( (_d[1] & (0xFFU)) );
  }
  if (_m->mux_master == 2) {
    _m->mux2_sig1_ro = (uint16_t) ( ((_d[2] & (0xFFU)) << 8U) | (_d[1] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
    _m->mux2_sig1_phys = (int32_t) TESTDB_mux2_sig1_ro_fromS(_m->mux2_sig1_ro);
#endif // TESTDB_USE_SIGFLOAT

  }
  if (_m->mux_master == 8) {
    _m->mux8_sig2_ro = (uint16_t) ( ((_d[3] & (0x7FU)) << 8U) | (_d[2] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
    _m->mux8_sig2_phys = (sigfloat_t)(TESTDB_mux8_sig2_ro_fromS(_m->mux8_sig2_ro));
#endif // TESTDB_USE_SIGFLOAT

  }
  if (_m->mux_master == 3) {
    _m->mux3_sig1 = (uint8_t) ( (_d[2] & (0xFFU)) );
  }
  if (_m->mux_master == 0) {
    _m->mux0_sig3 = (uint8_t) ( (_d[2] & (0xFFU)) );
  }
  if (_m->mux_master == 7) {
    _m->mux7_sig2_ro = (uint16_t) ( ((_d[3] & (0x7FU)) << 8U) | (_d[2] & (0xFFU)) );
#ifdef TESTDB_USE_SIGFLOAT
    _m->mux7_sig2_phys = (sigfloat_t)(TESTDB_mux7_sig2_ro_fromS(_m->mux7_sig2_ro));
#endif // TESTDB_USE_SIGFLOAT

  }
  if (_m->mux_master == 3) {
    _m->mux4_sig3 = (uint16_t) ( ((_d[4] & (0xFFU)) << 8U) | (_d[3] & (0xFFU)) );
  }
  if (_m->mux_master == 0) {
    _m->mux0_sig2 = (uint8_t) ( (_d[3] & (0xFFU)) );
  }
  if (_m->mux_master == 0) {
    _m->mux0_sig1 = (uint8_t) ( (_d[4] & (0xFFU)) );
  }

#ifdef TESTDB_USE_DIAG_MONITORS
  _m->mon1.dlc_error = (dlc_ < MUX_SIG_TEST1_DLC);
  _m->mon1.last_cycle = GetSystemTick();
  _m->mon1.frame_cnt++;

  FMon_MUX_SIG_TEST1_testdb(&_m->mon1, MUX_SIG_TEST1_CANID);
#endif // TESTDB_USE_DIAG_MONITORS

  return MUX_SIG_TEST1_CANID;
}
```
 
 